### PR TITLE
Add DevSkits OS 2.0 retro browser desktop (index.html, style.css, app.js)

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,543 @@
+const APPS = {
+  terminal: { title: "Terminal", icon: ">_" },
+  contact: { title: "Contact", icon: "☎" },
+  donate: { title: "Donate", icon: "$" },
+  projects: { title: "Projects", icon: "⌘" },
+  loki: { title: "Loki", icon: "🐾" },
+  notes: { title: "Notes", icon: "✎" },
+  links: { title: "Links", icon: "↗" },
+  about: { title: "About", icon: "i" },
+  recycle: { title: "Recycle Bin", icon: "🗑" }
+};
+
+const state = {
+  windows: new Map(),
+  z: 5,
+  history: [],
+  historyIndex: -1,
+  themes: ["default", "graphite", "paper"],
+  activeTheme: localStorage.getItem("devskits-theme") || "default"
+};
+
+const $ = (sel) => document.querySelector(sel);
+const desktop = $("#desktop");
+const iconContainer = $("#desktop-icons");
+const windowLayer = $("#window-layer");
+const taskButtons = $("#task-buttons");
+const startMenu = $("#start-menu");
+const startBtn = $("#start-btn");
+
+function init() {
+  applyTheme(state.activeTheme);
+  buildDesktopIcons();
+  bindGlobalUI();
+  startBootSequence();
+  setInterval(updateClock, 1000);
+  updateClock();
+}
+
+function startBootSequence() {
+  const boot = $("#boot-screen");
+  const bar = $("#boot-bar");
+  const status = $("#boot-status");
+  const lines = [
+    "Initializing identity shell...",
+    "Loading modules: terminal, notes, loki...",
+    "Mounting localStorage volumes...",
+    "Bringing desktop online..."
+  ];
+  let i = 0;
+  bar.style.width = "0%";
+  const total = 3200;
+  const interval = 800;
+  status.textContent = lines[0];
+  const tick = setInterval(() => {
+    i += 1;
+    bar.style.width = `${Math.min(100, (i * interval / total) * 100)}%`;
+    status.textContent = lines[Math.min(i, lines.length - 1)];
+  }, interval);
+
+  setTimeout(() => {
+    clearInterval(tick);
+    boot.classList.add("hidden");
+    desktop.classList.remove("hidden");
+    restoreSession();
+  }, total);
+}
+
+function buildDesktopIcons() {
+  const tpl = $("#desktop-icon-template");
+  Object.entries(APPS).forEach(([id, app]) => {
+    const node = tpl.content.firstElementChild.cloneNode(true);
+    node.dataset.app = id;
+    node.querySelector(".icon-glyph").textContent = app.icon;
+    node.querySelector(".icon-label").textContent = app.title;
+    node.addEventListener("dblclick", () => openApp(id));
+    node.addEventListener("click", () => node.focus());
+    iconContainer.appendChild(node);
+  });
+}
+
+function bindGlobalUI() {
+  startBtn.addEventListener("click", () => {
+    const expanded = !startMenu.classList.contains("hidden");
+    startMenu.classList.toggle("hidden", expanded);
+    startBtn.setAttribute("aria-expanded", String(!expanded));
+  });
+
+  startMenu.addEventListener("click", (e) => {
+    const btn = e.target.closest("button[data-open]");
+    if (!btn) return;
+    openApp(btn.dataset.open);
+    hideMenu();
+  });
+
+  $("#menu-reboot").addEventListener("click", () => rebootSystem());
+  $("#menu-shutdown").addEventListener("click", () => fakeShutdown());
+  document.addEventListener("click", (e) => {
+    if (!startMenu.contains(e.target) && e.target !== startBtn) hideMenu();
+  });
+}
+
+function hideMenu() {
+  startMenu.classList.add("hidden");
+  startBtn.setAttribute("aria-expanded", "false");
+}
+
+function openApp(appId) {
+  if (!APPS[appId]) return;
+  if (appId === "recycle") {
+    alert("Recycle Bin is decorative in this build.");
+    return;
+  }
+  if (state.windows.has(appId)) {
+    restoreWindow(appId);
+    focusWindow(appId);
+    return;
+  }
+
+  const win = $("#window-template").content.firstElementChild.cloneNode(true);
+  const meta = APPS[appId];
+  win.dataset.app = appId;
+  win.querySelector(".window-title").textContent = `${meta.title} - DevSkits OS 2.0`;
+  win.style.left = `${90 + state.windows.size * 20}px`;
+  win.style.top = `${80 + state.windows.size * 18}px`;
+  win.style.zIndex = ++state.z;
+
+  const content = win.querySelector(".window-content");
+  renderAppContent(appId, content);
+  wireWindowControls(win, appId);
+  enableDragging(win, appId);
+  windowLayer.appendChild(win);
+  state.windows.set(appId, { el: win, minimized: false, maximized: false });
+  createTaskButton(appId, meta.title);
+  focusWindow(appId);
+  persistSession();
+}
+
+function renderAppContent(appId, container) {
+  const creators = {
+    terminal: terminalContent,
+    contact: contactContent,
+    donate: donateContent,
+    projects: projectsContent,
+    loki: lokiContent,
+    notes: notesContent,
+    links: linksContent,
+    about: aboutContent
+  };
+  const fn = creators[appId];
+  container.innerHTML = "";
+  if (fn) fn(container);
+}
+
+function wireWindowControls(win, appId) {
+  win.addEventListener("mousedown", () => focusWindow(appId));
+  win.querySelector(".win-close").addEventListener("click", () => closeWindow(appId));
+  win.querySelector(".win-min").addEventListener("click", () => minimizeWindow(appId));
+  win.querySelector(".win-max").addEventListener("click", () => toggleMaximize(appId));
+  win.querySelector(".window-titlebar").addEventListener("dblclick", () => toggleMaximize(appId));
+}
+
+function createTaskButton(appId, title) {
+  const btn = document.createElement("button");
+  btn.className = "task-btn";
+  btn.dataset.app = appId;
+  btn.textContent = title;
+  btn.addEventListener("click", () => {
+    const rec = state.windows.get(appId);
+    if (!rec) return;
+    if (rec.minimized) restoreWindow(appId);
+    else if (rec.el.classList.contains("active")) minimizeWindow(appId);
+    else focusWindow(appId);
+  });
+  taskButtons.appendChild(btn);
+}
+
+function focusWindow(appId) {
+  state.windows.forEach((rec, id) => {
+    rec.el.classList.toggle("active", id === appId);
+    const task = taskButtons.querySelector(`[data-app="${id}"]`);
+    task?.classList.toggle("active", id === appId);
+  });
+  const rec = state.windows.get(appId);
+  if (!rec) return;
+  rec.el.style.zIndex = ++state.z;
+}
+
+function closeWindow(appId) {
+  const rec = state.windows.get(appId);
+  if (!rec) return;
+  rec.el.remove();
+  state.windows.delete(appId);
+  taskButtons.querySelector(`[data-app="${appId}"]`)?.remove();
+  persistSession();
+}
+
+function minimizeWindow(appId) {
+  const rec = state.windows.get(appId);
+  if (!rec) return;
+  rec.minimized = true;
+  rec.el.classList.add("hidden");
+  taskButtons.querySelector(`[data-app="${appId}"]`)?.classList.remove("active");
+  persistSession();
+}
+
+function restoreWindow(appId) {
+  const rec = state.windows.get(appId);
+  if (!rec) return;
+  rec.minimized = false;
+  rec.el.classList.remove("hidden");
+  focusWindow(appId);
+  persistSession();
+}
+
+function toggleMaximize(appId) {
+  const rec = state.windows.get(appId);
+  if (!rec || rec.minimized) return;
+  if (!rec.maximized) {
+    rec.prev = {
+      left: rec.el.style.left,
+      top: rec.el.style.top,
+      width: rec.el.style.width,
+      height: rec.el.style.height
+    };
+    rec.el.style.left = "0";
+    rec.el.style.top = "0";
+    rec.el.style.width = "100%";
+    rec.el.style.height = "calc(100% - 2.3rem)";
+    rec.maximized = true;
+  } else {
+    Object.assign(rec.el.style, rec.prev || {});
+    rec.maximized = false;
+  }
+  persistSession();
+}
+
+function enableDragging(win, appId) {
+  const bar = win.querySelector(".window-titlebar");
+  let drag = null;
+
+  bar.addEventListener("pointerdown", (e) => {
+    const rec = state.windows.get(appId);
+    if (!rec || rec.maximized || e.target.closest("button")) return;
+    const rect = win.getBoundingClientRect();
+    drag = { offsetX: e.clientX - rect.left, offsetY: e.clientY - rect.top };
+    bar.setPointerCapture(e.pointerId);
+  });
+
+  bar.addEventListener("pointermove", (e) => {
+    if (!drag) return;
+    const maxX = window.innerWidth - 120;
+    const maxY = window.innerHeight - 80;
+    const x = Math.max(0, Math.min(maxX, e.clientX - drag.offsetX));
+    const y = Math.max(0, Math.min(maxY, e.clientY - drag.offsetY));
+    win.style.left = `${x}px`;
+    win.style.top = `${y}px`;
+  });
+
+  bar.addEventListener("pointerup", () => {
+    if (drag) persistSession();
+    drag = null;
+  });
+}
+
+function terminalContent(container) {
+  container.innerHTML = `
+    <div class="terminal">
+      <div class="terminal-output" id="terminal-output"></div>
+      <div class="terminal-input-line">
+        <span>C:\\DEVSKITS&gt;</span>
+        <input id="terminal-input" autocomplete="off" aria-label="Terminal command input" />
+      </div>
+    </div>`;
+
+  const output = container.querySelector("#terminal-output");
+  const input = container.querySelector("#terminal-input");
+
+  const print = (text) => {
+    output.textContent += `${text}\n`;
+    output.scrollTop = output.scrollHeight;
+  };
+  print("DevSkits terminal online. type 'help' for commands.");
+
+  input.addEventListener("keydown", (e) => {
+    if (e.key === "Enter") {
+      const cmd = input.value.trim();
+      print(`C:\\DEVSKITS> ${cmd}`);
+      runTerminalCommand(cmd, print, output);
+      if (cmd) {
+        state.history.push(cmd);
+        state.historyIndex = state.history.length;
+      }
+      input.value = "";
+    }
+    if (e.key === "ArrowUp") {
+      e.preventDefault();
+      if (!state.history.length) return;
+      state.historyIndex = Math.max(0, state.historyIndex - 1);
+      input.value = state.history[state.historyIndex] || "";
+    }
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      if (!state.history.length) return;
+      state.historyIndex = Math.min(state.history.length, state.historyIndex + 1);
+      input.value = state.history[state.historyIndex] || "";
+    }
+  });
+  setTimeout(() => input.focus(), 20);
+}
+
+function runTerminalCommand(raw, print, outputEl) {
+  const cmd = raw.toLowerCase();
+  const map = {
+    help: "Commands: help, about, contact, donate, links, projects, loki, github, clear, date, whoami, theme, reboot",
+    about: "DevSkits OS 2.0 is Travis Ramsey's retro desktop identity hub.",
+    contact: "Email: DevSkits@icloud.com | Phone: 916-420-3052",
+    donate: "Support: GoFundMe / Venmo / Cash App / Chime",
+    links: "github.com/DevSkits916 | facebook.com/DevSkits | reddit.com/u/DevSkits",
+    projects: "Use Projects app for full catalog.",
+    loki: "Loki: German Shepherd, companion, mascot, legend.",
+    github: "Opening GitHub profile...",
+    date: new Date().toString(),
+    whoami: "travis.ramsey@devskits",
+    theme: "Theme toggled.",
+    reboot: "Rebooting DevSkits OS 2.0..."
+  };
+
+  if (!cmd) return;
+  if (cmd === "clear") {
+    outputEl.textContent = "";
+    return;
+  }
+  if (cmd === "github") {
+    window.open("https://github.com/DevSkits916", "_blank", "noopener");
+  }
+  if (cmd === "theme") {
+    cycleTheme();
+  }
+  if (cmd === "reboot") {
+    setTimeout(rebootSystem, 450);
+  }
+  print(map[cmd] || `Unknown command: ${raw}. type 'help'.`);
+}
+
+function contactContent(container) {
+  const rows = [
+    ["Name", "Travis Ramsey"],
+    ["Brand", "DevSkits"],
+    ["Email", "DevSkits@icloud.com"],
+    ["Phone", "916-420-3052"],
+    ["GitHub", "https://github.com/DevSkits916"],
+    ["Facebook", "https://www.facebook.com/DevSkits?mibextid=wwXIfr"],
+    ["Reddit", "https://www.reddit.com/u/DevSkits/s/RE9W0sZoV1"],
+    ["X / Twitter", "@Devskits916"],
+    ["GoFundMe", "https://gofund.me/6bbc0274e"],
+    ["Venmo", "@DevSkits"],
+    ["Cash App", "$DevSkits916"],
+    ["Chime", "$DevSkits916"]
+  ];
+  container.innerHTML = `<div class="app-grid">${rows.map(([k,v]) => `
+    <div class="info-row"><strong>${k}</strong><span>${toLink(v)}</span><button class="copy-btn" data-copy="${escapeHtml(v)}">Copy</button></div>`).join("")}
+  </div>`;
+  wireCopyButtons(container);
+}
+
+function donateContent(container) {
+  container.innerHTML = `
+    <h3>Support DevSkits</h3>
+    <p>Fuel builds, upgrades, and rescue-friendly content with Loki at the center of the story.</p>
+    <div class="app-grid">
+      ${donationItem("GoFundMe", "https://gofund.me/6bbc0274e")}
+      ${donationItem("Venmo", "https://venmo.com/u/DevSkits")}
+      ${donationItem("Cash App", "https://cash.app/$DevSkits916")}
+      ${donationItem("Chime", "https://chime.com/$DevSkits916")}
+      ${donationItem("PayPal (placeholder)", "https://paypal.me/")}
+    </div>`;
+}
+
+function projectsContent(container) {
+  const projects = [
+    ["DevSkits OS 2.0", "Retro browser desktop that acts as a digital identity hub.", "active"],
+    ["Paste Happy Studio", "Creative pasteboard utility for quick snippet workflows.", "building"],
+    ["Terminal Portfolio Generator", "CLI-style portfolio scaffolder for creators.", "building"],
+    ["LokiMon", "Companion tracking concept inspired by Loki's daily adventures.", "concept"],
+    ["Timeline Vault", "Visual time capsule for milestones and releases.", "concept"],
+    ["Notes Forge", "Offline-first notes system with templated memory prompts.", "building"],
+    ["Asset Factory", "Batch utility for generating branded visual assets.", "concept"]
+  ];
+  container.innerHTML = projects.map(([name, desc, status]) => `
+    <article class="project-card">
+      <h4>${name}</h4>
+      <p>${desc}</p>
+      <div class="badges"><span class="tag status-${status}">${status}</span>
+      <button class="link-btn">Open</button></div>
+    </article>`).join("");
+}
+
+function lokiContent(container) {
+  container.innerHTML = `
+    <div class="app-grid">
+      <h3>Loki // Companion • Mascot • Legend</h3>
+      <p>Loki is the loyal German Shepherd at the heart of DevSkits stories—part protector, part morale engine, full-time legend.</p>
+      <div class="loki-avatar">Loki Avatar Zone<br/>[ future photo/gallery slot ]</div>
+      <div class="gallery"><div>Paw Cam</div><div>Guard Mode</div><div>Adventure Log</div></div>
+    </div>`;
+}
+
+function notesContent(container) {
+  const saved = localStorage.getItem("devskits-notes") || "";
+  container.innerHTML = `<strong>notes.txt</strong><textarea class="notes-editor" aria-label="Notes editor">${escapeHtml(saved)}</textarea>`;
+  const ta = container.querySelector("textarea");
+  ta.addEventListener("input", () => localStorage.setItem("devskits-notes", ta.value));
+}
+
+function linksContent(container) {
+  const links = [
+    ["GitHub", "https://github.com/DevSkits916"],
+    ["Facebook", "https://www.facebook.com/DevSkits?mibextid=wwXIfr"],
+    ["Reddit", "https://www.reddit.com/u/DevSkits/s/RE9W0sZoV1"],
+    ["X", "https://x.com/Devskits916"],
+    ["GoFundMe", "https://gofund.me/6bbc0274e"]
+  ];
+  container.innerHTML = `<div class="app-grid">${links.map(([n,u]) => `<button class="link-btn" data-url="${u}">${n}</button>`).join("")}</div>`;
+  container.querySelectorAll(".link-btn").forEach((b) => b.addEventListener("click", () => window.open(b.dataset.url, "_blank", "noopener")));
+}
+
+function aboutContent(container) {
+  container.innerHTML = `
+    <h3>About DevSkits OS 2.0</h3>
+    <p>DevSkits OS 2.0 is a browser-based retro operating environment designed as Travis Ramsey's digital identity hub under the DevSkits brand.</p>
+    <p>It blends a vintage desktop metaphor with terminal culture: windows, taskbar, icons, and working mini-apps for projects, contact, notes, donations, and Loki content.</p>
+    <p><strong>Identity statement:</strong> Build useful things, stay human, and keep the legend close.</p>`;
+}
+
+function donationItem(name, url) {
+  return `<div class="info-row"><strong>${name}</strong><span>${url}</span><button class="link-btn" onclick="window.open('${url}','_blank','noopener')">Open</button></div>`;
+}
+
+function wireCopyButtons(scope) {
+  scope.querySelectorAll(".copy-btn").forEach((btn) => {
+    btn.addEventListener("click", async () => {
+      try {
+        await navigator.clipboard.writeText(btn.dataset.copy);
+      } catch {
+        const ta = document.createElement("textarea");
+        ta.value = btn.dataset.copy;
+        document.body.appendChild(ta);
+        ta.select();
+        document.execCommand("copy");
+        ta.remove();
+      }
+      btn.dataset.copied = "true";
+      btn.textContent = "Copied";
+      setTimeout(() => {
+        btn.dataset.copied = "false";
+        btn.textContent = "Copy";
+      }, 900);
+    });
+  });
+}
+
+function toLink(value) {
+  if (value.startsWith("http")) return `<a href="${value}" target="_blank" rel="noopener">${value}</a>`;
+  return escapeHtml(value);
+}
+
+function escapeHtml(str) {
+  return str.replace(/[&<>"]/g, (m) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[m]));
+}
+
+function updateClock() {
+  $("#clock").textContent = new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+
+function applyTheme(theme) {
+  if (theme === "default") document.body.removeAttribute("data-theme");
+  else document.body.setAttribute("data-theme", theme);
+  state.activeTheme = theme;
+  localStorage.setItem("devskits-theme", theme);
+}
+
+function cycleTheme() {
+  const idx = state.themes.indexOf(state.activeTheme);
+  applyTheme(state.themes[(idx + 1) % state.themes.length]);
+}
+
+function persistSession() {
+  const session = [];
+  state.windows.forEach((rec, appId) => {
+    session.push({
+      appId,
+      minimized: rec.minimized,
+      maximized: rec.maximized,
+      style: {
+        left: rec.el.style.left,
+        top: rec.el.style.top,
+        width: rec.el.style.width,
+        height: rec.el.style.height
+      }
+    });
+  });
+  localStorage.setItem("devskits-session", JSON.stringify(session));
+}
+
+function restoreSession() {
+  let items = [];
+  try {
+    items = JSON.parse(localStorage.getItem("devskits-session") || "[]");
+  } catch {
+    items = [];
+  }
+  items.forEach((item) => {
+    openApp(item.appId);
+    const rec = state.windows.get(item.appId);
+    if (!rec) return;
+    Object.assign(rec.el.style, item.style || {});
+    if (item.maximized) toggleMaximize(item.appId);
+    if (item.minimized) minimizeWindow(item.appId);
+  });
+  if (!items.length) openApp("about");
+}
+
+function fakeShutdown() {
+  const overlay = document.createElement("div");
+  overlay.className = "shutdown-overlay";
+  overlay.innerHTML = `<div><h2>It is now safe to close your browser.</h2><p>DevSkits OS is sleeping...</p><button class="link-btn" id="wake-btn">Wake</button></div>`;
+  desktop.appendChild(overlay);
+  overlay.querySelector("#wake-btn").addEventListener("click", () => overlay.remove());
+  hideMenu();
+}
+
+function rebootSystem() {
+  hideMenu();
+  localStorage.setItem("devskits-session", "[]");
+  state.windows.forEach((rec) => rec.el.remove());
+  state.windows.clear();
+  taskButtons.innerHTML = "";
+  desktop.classList.add("hidden");
+  $("#boot-screen").classList.remove("hidden");
+  startBootSequence();
+}
+
+init();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>DevSkits OS 2.0</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div id="boot-screen" class="boot-screen" aria-live="polite">
+    <div class="boot-panel">
+      <pre class="boot-logo">██████╗ ███████╗██╗   ██╗███████╗██╗  ██╗██╗████████╗███████╗
+██╔══██╗██╔════╝██║   ██║██╔════╝██║ ██╔╝██║╚══██╔══╝██╔════╝
+██║  ██║█████╗  ██║   ██║███████╗█████╔╝ ██║   ██║   ███████╗
+██║  ██║██╔══╝  ╚██╗ ██╔╝╚════██║██╔═██╗ ██║   ██║   ╚════██║
+██████╔╝███████╗ ╚████╔╝ ███████║██║  ██╗██║   ██║   ███████║
+╚═════╝ ╚══════╝  ╚═══╝  ╚══════╝╚═╝  ╚═╝╚═╝   ╚═╝   ╚══════╝
+      </pre>
+      <h1>DevSkits OS 2.0</h1>
+      <p id="boot-status">Initializing identity shell...</p>
+      <div class="boot-progress"><span id="boot-bar"></span></div>
+    </div>
+  </div>
+
+  <div id="desktop" class="desktop hidden" role="application" aria-label="DevSkits Desktop">
+    <div class="scanlines"></div>
+    <div id="desktop-icons" class="desktop-icons"></div>
+    <div id="window-layer" class="window-layer"></div>
+
+    <div id="start-menu" class="start-menu hidden" aria-hidden="true">
+      <div class="start-header">DevSkits Menu</div>
+      <button data-open="terminal">Terminal</button>
+      <button data-open="projects">Projects</button>
+      <button data-open="notes">Notes</button>
+      <button data-open="links">Links</button>
+      <button data-open="about">About</button>
+      <button data-open="contact">Contact</button>
+      <hr />
+      <button id="menu-reboot">Reboot</button>
+      <button id="menu-shutdown">Shut Down</button>
+    </div>
+
+    <footer class="taskbar">
+      <button id="start-btn" class="start-btn" aria-expanded="false">DevSkits</button>
+      <div id="task-buttons" class="task-buttons" aria-label="Open windows"></div>
+      <div class="system-tray">
+        <span class="tray-label">SYS</span>
+        <time id="clock"></time>
+      </div>
+    </footer>
+  </div>
+
+  <template id="desktop-icon-template">
+    <button class="desktop-icon" type="button">
+      <span class="icon-glyph">◼</span>
+      <span class="icon-label"></span>
+    </button>
+  </template>
+
+  <template id="window-template">
+    <section class="window" role="dialog" aria-modal="false">
+      <header class="window-titlebar">
+        <span class="window-title"></span>
+        <div class="window-controls">
+          <button class="win-min" aria-label="Minimize">_</button>
+          <button class="win-max" aria-label="Maximize">□</button>
+          <button class="win-close" aria-label="Close">✕</button>
+        </div>
+      </header>
+      <div class="window-content"></div>
+    </section>
+  </template>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,354 @@
+:root {
+  --bg: #c8c8c8;
+  --panel: #efefef;
+  --border-dark: #2b2b2b;
+  --border-mid: #6f6f6f;
+  --text: #121212;
+  --accent: #1e1e1e;
+  --title-bg: linear-gradient(90deg, #3a3a3a 0%, #1b1b1b 100%);
+  --title-color: #f8f8f8;
+  --taskbar: #b8b8b8;
+}
+
+body[data-theme="graphite"] {
+  --bg: #9da0a5;
+  --panel: #e0e2e6;
+  --border-dark: #111;
+  --border-mid: #52565d;
+  --text: #101113;
+  --accent: #000;
+  --title-bg: linear-gradient(90deg, #4a4f57 0%, #2c3138 100%);
+  --title-color: #f4f4f4;
+  --taskbar: #a1a5ab;
+}
+
+body[data-theme="paper"] {
+  --bg: #d7d5cf;
+  --panel: #f7f4ee;
+  --border-dark: #333;
+  --border-mid: #7e776d;
+  --text: #1d1a16;
+  --accent: #16130f;
+  --title-bg: linear-gradient(90deg, #635a52 0%, #3e3731 100%);
+  --title-color: #fff;
+  --taskbar: #c1bbb2;
+}
+
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  height: 100vh;
+  font-family: "Lucida Console", "Courier New", monospace;
+  color: var(--text);
+  background: #000;
+  overflow: hidden;
+}
+
+.hidden { display: none !important; }
+
+.boot-screen {
+  position: fixed;
+  inset: 0;
+  background: #000;
+  color: #d0d0d0;
+  display: grid;
+  place-items: center;
+  padding: 1rem;
+}
+
+.boot-panel {
+  width: min(760px, 100%);
+  border: 2px solid #999;
+  padding: 1rem;
+  background: #0c0c0c;
+  box-shadow: 0 0 0 2px #333;
+}
+
+.boot-logo {
+  margin: 0;
+  font-size: clamp(0.38rem, 1.2vw, 0.74rem);
+  line-height: 1.1;
+  color: #f5f5f5;
+  overflow-x: auto;
+}
+
+.boot-panel h1 { margin: 0.8rem 0 0.3rem; font-size: clamp(1.05rem, 2.3vw, 1.4rem); }
+.boot-panel p { margin: 0.3rem 0 0.7rem; min-height: 1.3rem; }
+.boot-progress {
+  height: 18px;
+  border: 2px inset #666;
+  background: #111;
+}
+.boot-progress span {
+  display: block;
+  height: 100%;
+  width: 0;
+  background: repeating-linear-gradient(90deg, #e5e5e5 0 7px, #9f9f9f 7px 14px);
+}
+
+.desktop {
+  position: fixed;
+  inset: 0;
+  background: radial-gradient(circle at 20% 15%, #d7d7d7, var(--bg));
+}
+
+.scanlines {
+  pointer-events: none;
+  position: absolute;
+  inset: 0;
+  background: repeating-linear-gradient(
+      to bottom,
+      rgba(255, 255, 255, 0.025) 0,
+      rgba(255, 255, 255, 0.025) 1px,
+      rgba(0, 0, 0, 0.02) 2px,
+      rgba(0, 0, 0, 0.02) 3px
+  );
+}
+
+.desktop-icons {
+  position: absolute;
+  top: 0.5rem;
+  left: 0.5rem;
+  right: 0.5rem;
+  bottom: 3rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(90px, 1fr));
+  grid-auto-rows: min-content;
+  gap: 0.3rem;
+  align-content: start;
+  max-width: 520px;
+}
+
+.desktop-icon {
+  width: 90px;
+  min-height: 90px;
+  border: 1px solid transparent;
+  background: transparent;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+  color: var(--text);
+  cursor: pointer;
+}
+.desktop-icon:hover, .desktop-icon:focus-visible {
+  border-color: var(--border-dark);
+  background: rgba(255,255,255,0.4);
+}
+.icon-glyph {
+  width: 36px;
+  height: 30px;
+  border: 2px outset #999;
+  background: var(--panel);
+  display: grid;
+  place-items: center;
+  font-size: 0.8rem;
+}
+.icon-label { font-size: 0.74rem; text-align: center; }
+
+.window-layer { position: absolute; inset: 0 0 2.25rem 0; }
+.window {
+  position: absolute;
+  min-width: 280px;
+  min-height: 180px;
+  width: min(560px, 92vw);
+  height: min(380px, 74vh);
+  border: 2px solid var(--border-dark);
+  box-shadow: 0 0 0 2px #fff inset, 3px 3px 0 rgba(0, 0, 0, 0.35);
+  background: var(--panel);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.window.active .window-titlebar { filter: contrast(1.1); }
+.window-titlebar {
+  background: var(--title-bg);
+  color: var(--title-color);
+  padding: 0.22rem 0.35rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  cursor: move;
+  user-select: none;
+}
+.window-title { font-size: 0.75rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.window-controls { display: flex; gap: 0.2rem; }
+.window-controls button {
+  width: 24px;
+  height: 20px;
+  border: 2px outset #aaa;
+  background: #ddd;
+  font-size: 0.7rem;
+  cursor: pointer;
+}
+.window-content {
+  flex: 1;
+  border-top: 2px solid #b4b4b4;
+  background: #f9f9f9;
+  overflow: auto;
+  padding: 0.65rem;
+  font-size: 0.84rem;
+}
+
+.taskbar {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 2.35rem;
+  border-top: 2px solid var(--border-dark);
+  background: var(--taskbar);
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.2rem;
+  z-index: 2500;
+}
+.start-btn, .task-btn {
+  height: 100%;
+  border: 2px outset #eee;
+  background: #d9d9d9;
+  font-family: inherit;
+  cursor: pointer;
+}
+.start-btn { min-width: 95px; font-weight: 700; }
+.task-buttons { flex: 1; display: flex; gap: 0.2rem; overflow: auto; }
+.task-btn {
+  min-width: 120px;
+  max-width: 220px;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+.task-btn.active { border-style: inset; background: #c8c8c8; }
+
+.system-tray {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  border: 2px inset #eee;
+  padding: 0.25rem 0.45rem;
+  min-width: 95px;
+  justify-content: space-between;
+}
+.tray-label { font-size: 0.65rem; letter-spacing: 0.05em; }
+
+.start-menu {
+  position: absolute;
+  left: 0.2rem;
+  bottom: 2.5rem;
+  width: min(280px, 90vw);
+  border: 2px solid var(--border-dark);
+  background: var(--panel);
+  box-shadow: 4px 4px 0 rgba(0,0,0,0.3);
+  padding: 0.4rem;
+  display: grid;
+  gap: 0.3rem;
+  z-index: 2600;
+}
+.start-header {
+  background: var(--title-bg);
+  color: var(--title-color);
+  font-size: 0.75rem;
+  padding: 0.3rem;
+}
+.start-menu button {
+  text-align: left;
+  border: 2px outset #ccc;
+  padding: 0.35rem;
+  background: #ececec;
+  font-family: inherit;
+}
+
+.app-grid { display: grid; gap: 0.65rem; }
+.info-row { display: grid; grid-template-columns: 85px 1fr auto; gap: 0.35rem; align-items: center; }
+.info-row a { color: inherit; }
+.copy-btn, .link-btn, .tag {
+  border: 2px outset #bbb;
+  background: #ececec;
+  font-family: inherit;
+  cursor: pointer;
+  padding: 0.22rem 0.45rem;
+}
+.copy-btn[data-copied="true"] { border-style: inset; }
+
+.terminal {
+  background: #0a0a0a;
+  color: #d3d3d3;
+  border: 2px inset #666;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+.terminal-output { flex: 1; overflow: auto; padding: 0.55rem; white-space: pre-wrap; }
+.terminal-input-line {
+  border-top: 1px solid #444;
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.4rem;
+}
+.terminal-input-line input {
+  flex: 1;
+  background: #111;
+  color: #e4e4e4;
+  border: 1px solid #777;
+  font-family: inherit;
+  padding: 0.35rem;
+}
+
+.project-card {
+  border: 2px groove #bbb;
+  background: #fdfdfd;
+  padding: 0.5rem;
+}
+.badges { display: flex; gap: 0.3rem; margin: 0.3rem 0; }
+.tag { font-size: 0.67rem; text-transform: uppercase; }
+.status-active { background: #d0e0d0; }
+.status-building { background: #e3dfd1; }
+.status-concept { background: #e2d8d8; }
+
+.loki-avatar {
+  border: 2px dashed #777;
+  min-height: 120px;
+  background: repeating-linear-gradient(135deg, #ececec, #ececec 10px, #dbdbdb 10px, #dbdbdb 20px);
+  display: grid;
+  place-items: center;
+  font-size: 0.85rem;
+  text-align: center;
+  padding: 0.7rem;
+}
+.gallery { display: grid; grid-template-columns: repeat(3, 1fr); gap: 0.35rem; }
+.gallery div { border: 1px solid #888; min-height: 55px; background: #efefef; display: grid; place-items: center; font-size: 0.7rem; }
+
+.notes-editor {
+  width: 100%;
+  height: calc(100% - 1.9rem);
+  resize: none;
+  border: 2px inset #999;
+  background: #fffff4;
+  font-family: "Courier New", monospace;
+  padding: 0.55rem;
+}
+
+.shutdown-overlay {
+  position: absolute;
+  inset: 0;
+  background: #020202;
+  color: #e4e4e4;
+  display: grid;
+  place-items: center;
+  z-index: 3000;
+  text-align: center;
+  padding: 1rem;
+}
+
+@media (max-width: 780px) {
+  .desktop-icons { max-width: 100%; grid-template-columns: repeat(auto-fill, minmax(78px, 1fr)); }
+  .window { min-width: 240px; width: 95vw; height: 66vh; }
+  .task-btn { min-width: 86px; }
+  .info-row { grid-template-columns: 1fr; }
+}


### PR DESCRIPTION
### Motivation
- Provide a single-file, framework-free retro desktop experience that acts as Travis Ramsey / DevSkits' digital identity hub using only HTML, CSS, and vanilla JS. 
- Emulate a vintage Windows-style desktop with monochrome/terminal visual language while exposing useful mini-apps (terminal, contact, projects, donate, notes, links, loki, about) that are usable from a browser.

### Description
- Added three new files: `index.html`, `style.css`, and `app.js`, which implement the full UI shell (boot splash, desktop surface, icon grid, taskbar, start menu, and template-driven window system). 
- Implemented a modular window manager in `app.js` with draggable titlebars (pointer events), focus/z-index stacking, minimize/restore/close, maximize/restore, taskbar button syncing, and double-click titlebar maximize behavior. 
- Built the requested mini-apps and UI pieces in `app.js`: a working `Terminal` with command parsing and history, `Contact` with copy buttons, `Donate` with external links, `Projects`, `Loki`, `Notes` with autosave to `localStorage`, `Links`, and `About`. 
- Added theme variants, CRT scanline polish, responsive/mobile constraints, and localStorage persistence for notes, selected theme (`devskits-theme`), and window/session state (`devskits-session`) to restore positions and visibility across reloads.

### Testing
- Ran a static JS syntax/check with `node --check app.js`, which completed successfully. 
- Launched a local HTTP server with `python3 -m http.server 8000` to validate the app can be served and loaded in a browser, which started successfully. 
- Attempted an automated browser smoke test (Playwright) to capture a screenshot, but the headless Chromium process crashed in this environment (SIGSEGV), so no screenshot artifact was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4437d16c0832d8db327a9d541e226)