### PR TITLE
Phase 3 foundation: shared state + Navigator, Inbox, and Build Log apps

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,6 +101,9 @@
   <script src="js/apps/about.js"></script>
   <script src="js/apps/settings.js"></script>
   <script src="js/apps/files.js"></script>
+  <script src="js/apps/browser.js"></script>
+  <script src="js/apps/inbox.js"></script>
+  <script src="js/apps/buildlog.js"></script>
   <script src="js/apps/terminal.js"></script>
   <script src="app.js"></script>
 </body>

--- a/js/apps/browser.js
+++ b/js/apps/browser.js
@@ -1,0 +1,124 @@
+(() => {
+  const { state, addActivity, setBrowserHistory } = window.DevSkitsState;
+
+  const browserState = {
+    history: [],
+    index: -1,
+    current: "devskits://home"
+  };
+
+  function retroPage(title, body) {
+    return `<article class="retro-web-page"><h2>${title}</h2>${body}</article>`;
+  }
+
+  function buildPageMap() {
+    const projects = (window.DevSkitsProjects || []).map((p) => `<li><b>${p.name}</b> <small>[${p.status}]</small><br/>${p.desc}</li>`).join("");
+    const notes = JSON.parse(localStorage.getItem("devskits-notes-v2") || "[]").map((n) => `<li>${n.name}</li>`).join("") || "<li>No notes yet.</li>";
+    const changelog = state.changelogEntries.map((e) => `<li><b>${e.phase}</b> / Build ${e.build} <small>${e.date}</small><br/>${e.note}</li>`).join("");
+    const pkg = state.packages.map((p) => `<li>${p.installed ? "[x]" : "[ ]"} ${p.name}</li>`).join("");
+    const labsUnlocked = state.packages.find((p) => p.id === "devskits-labs")?.installed;
+
+    return {
+      "devskits://home": retroPage("DevSkits Internal Network", `<p>Welcome to Navigator. This browser renders internal pages over the DevSkits protocol.</p><ul><li><a href="devskits://projects">Projects</a></li><li><a href="devskits://changelog">Changelog</a></li><li><a href="devskits://system-specs">System Specs</a></li><li><a href="devskits://packages">Installed Packages</a></li></ul>`),
+      "devskits://projects": retroPage("Projects Index", `<ol>${projects}</ol><p><button data-open-app="projects" class="link-btn">Open Projects App</button></p>`),
+      "devskits://contact": retroPage("Contact", `<p>Route support calls to Contact app or Links directory.</p><p><a href="devskits://donate">Support DevSkits</a> · <button data-open-app="contact" class="link-btn">Launch Contact</button></p>`),
+      "devskits://donate": retroPage("Donate", `<p>Support keeps the shell alive.</p><p><button data-open-app="donate" class="link-btn">Open Donate App</button></p>`),
+      "devskits://loki": retroPage("Loki Companion Dossier", `<p>Status: online. Mood: curious.</p><ul><li>Archive references hidden in Inbox/System folder.</li><li><button data-open-app="loki" class="link-btn">Open Loki App</button></li></ul>`),
+      "devskits://about": retroPage("About DevSkits OS", `<p>A monochrome Windows/terminal hybrid shell with modular internal apps.</p>`),
+      "devskits://changelog": retroPage("Build Changelog", `<ul>${changelog}</ul><p><button data-open-app="buildlog" class="link-btn">Open Build Log App</button></p>`),
+      "devskits://system-specs": retroPage("System Specs", `<ul><li>Kernel: IdentityShell 2.0</li><li>Display: CRT ${state.crt ? "enabled" : "disabled"}</li><li>Theme: ${state.activeTheme}</li><li>Wallpaper: ${state.wallpaper}</li></ul>`),
+      "devskits://packages": retroPage("Installed Packages", `<ul>${pkg}</ul>`),
+      "devskits://notes-index": retroPage("Notes Index", `<ul>${notes}</ul><p><button data-open-app="notes" class="link-btn">Open Notes</button></p>`),
+      "devskits://labs": labsUnlocked
+        ? retroPage("DevSkits Labs", `<p>Labs unlocked. Experimental modules queued.</p><ul><li>Prototype: App-to-app jump routing</li><li>Prototype: Lore crawler</li></ul>`)
+        : retroPage("DevSkits Labs", `<p>Access denied. Install package <b>DevSkits Labs</b> in Install Center when available.</p>`)
+    };
+  }
+
+  function isExternal(url) {
+    return /^https?:\/\//i.test(url);
+  }
+
+  function openUrl(rawUrl, options = {}) {
+    const url = (rawUrl || "").trim() || "devskits://home";
+    if (isExternal(url)) {
+      window.open(url, "_blank", "noopener");
+      addActivity("external-link", url);
+      return { external: true };
+    }
+
+    const pages = buildPageMap();
+    const html = pages[url] || retroPage("404 - Internal Page Missing", `<p>No route for <b>${url}</b>.</p><p><a href="devskits://home">Return home</a></p>`);
+    if (!options.skipHistory) {
+      browserState.history = browserState.history.slice(0, browserState.index + 1);
+      browserState.history.push(url);
+      browserState.index = browserState.history.length - 1;
+    }
+    browserState.current = url;
+    setBrowserHistory([url, ...state.browserHistory.filter((item) => item !== url)].slice(0, 30));
+    addActivity("browser-page", url);
+    return { url, html };
+  }
+
+  function render(container, options = {}) {
+    container.innerHTML = `
+      <div class="browser-shell">
+        <div class="browser-toolbar">
+          <button class="link-btn" data-nav="back">◀</button>
+          <button class="link-btn" data-nav="forward">▶</button>
+          <button class="link-btn" data-nav="reload">↻</button>
+          <input class="browser-address" aria-label="Navigator address" value="devskits://home" />
+          <button class="link-btn" data-nav="go">Go</button>
+        </div>
+        <div class="browser-view"></div>
+      </div>`;
+
+    const view = container.querySelector(".browser-view");
+    const address = container.querySelector(".browser-address");
+
+    function paint(result) {
+      if (!result || result.external) return;
+      view.innerHTML = result.html;
+      address.value = result.url;
+    }
+
+    function go(url, opts) {
+      const result = openUrl(url, opts);
+      paint(result);
+    }
+
+    go(options.url || browserState.current || "devskits://home");
+
+    container.addEventListener("click", (e) => {
+      const internal = e.target.closest("a[href^='devskits://']");
+      const appBtn = e.target.closest("[data-open-app]");
+      const nav = e.target.closest("[data-nav]")?.dataset.nav;
+
+      if (internal) {
+        e.preventDefault();
+        go(internal.getAttribute("href"));
+      }
+      if (appBtn) {
+        window.DevSkitsWindowManager.openApp(appBtn.dataset.openApp);
+      }
+      if (nav === "go") go(address.value);
+      if (nav === "reload") go(browserState.current, { skipHistory: true });
+      if (nav === "back" && browserState.index > 0) {
+        browserState.index -= 1;
+        go(browserState.history[browserState.index], { skipHistory: true });
+      }
+      if (nav === "forward" && browserState.index < browserState.history.length - 1) {
+        browserState.index += 1;
+        go(browserState.history[browserState.index], { skipHistory: true });
+      }
+    });
+
+    address.addEventListener("keydown", (e) => {
+      if (e.key === "Enter") go(address.value);
+    });
+  }
+
+  window.DevSkitsBrowser = { openUrl };
+  window.DevSkitsAppRegistry = window.DevSkitsAppRegistry || {};
+  window.DevSkitsAppRegistry.browser = render;
+})();

--- a/js/apps/buildlog.js
+++ b/js/apps/buildlog.js
@@ -1,0 +1,51 @@
+(() => {
+  const { state, addActivity } = window.DevSkitsState;
+
+  function render(container) {
+    container.innerHTML = `
+      <div class="buildlog-shell">
+        <div class="buildlog-tools">
+          <label>View
+            <select id="buildlog-view"><option value="timeline">Timeline</option><option value="list">List</option></select>
+          </label>
+          <label>Tag
+            <select id="buildlog-tag"><option value="all">All</option><option value="feature">feature</option><option value="fix">fix</option><option value="shell">shell</option><option value="app">app</option><option value="polish">polish</option></select>
+          </label>
+        </div>
+        <div id="buildlog-entries"></div>
+      </div>`;
+
+    const entriesEl = container.querySelector("#buildlog-entries");
+
+    function draw() {
+      const mode = container.querySelector("#buildlog-view").value;
+      const tag = container.querySelector("#buildlog-tag").value;
+      const rows = state.changelogEntries.filter((e) => tag === "all" || e.tags.includes(tag));
+      entriesEl.className = mode === "timeline" ? "buildlog-timeline" : "buildlog-list";
+      entriesEl.innerHTML = rows.map((entry) => `
+        <article class="build-entry">
+          <header><b>${entry.phase}</b> <span>Build ${entry.build}</span></header>
+          <small>${entry.date}</small>
+          <p>${entry.note}</p>
+          <div class="badges">${entry.tags.map((t) => `<span class="tag">${t}</span>`).join("")}<button class="link-btn" data-open-url="devskits://changelog">open in Navigator</button></div>
+        </article>
+      `).join("");
+    }
+
+    container.addEventListener("change", (e) => {
+      if (e.target.matches("#buildlog-view, #buildlog-tag")) draw();
+    });
+
+    container.addEventListener("click", (e) => {
+      const url = e.target.closest("[data-open-url]")?.dataset.openUrl;
+      if (!url) return;
+      window.DevSkitsWindowManager.openApp("browser", { url });
+      addActivity("buildlog-open-url", url);
+    });
+
+    draw();
+  }
+
+  window.DevSkitsAppRegistry = window.DevSkitsAppRegistry || {};
+  window.DevSkitsAppRegistry.buildlog = render;
+})();

--- a/js/apps/inbox.js
+++ b/js/apps/inbox.js
@@ -1,0 +1,107 @@
+(() => {
+  const { state, setInboxMessages, setInboxDrafts, addActivity } = window.DevSkitsState;
+  const folders = ["Inbox", "Sent", "Drafts", "Archive", "System"];
+
+  function byFolder(folder) {
+    return state.inboxMessages.filter((m) => m.folder === folder);
+  }
+
+  function render(container) {
+    let activeFolder = "Inbox";
+    let activeMessage = byFolder(activeFolder)[0]?.id;
+
+    container.innerHTML = `
+      <div class="inbox-shell">
+        <aside class="inbox-folders"></aside>
+        <section class="inbox-list-pane"><div class="inbox-controls"><button class="link-btn" id="compose-btn">Compose</button></div><div class="inbox-list"></div></section>
+        <section class="inbox-detail"><div class="inbox-placeholder">Select a message.</div></section>
+      </div>`;
+
+    const folderEl = container.querySelector(".inbox-folders");
+    const listEl = container.querySelector(".inbox-list");
+    const detailEl = container.querySelector(".inbox-detail");
+
+    function drawFolders() {
+      folderEl.innerHTML = folders.map((folder) => `<button class="task-btn ${folder === activeFolder ? "active" : ""}" data-folder="${folder}">${folder} <small>(${byFolder(folder).length})</small></button>`).join("");
+    }
+
+    function drawList() {
+      const items = byFolder(activeFolder);
+      if (!items.length) {
+        listEl.innerHTML = '<p class="inbox-empty">No messages.</p>';
+        detailEl.innerHTML = '<div class="inbox-placeholder">Folder is empty.</div>';
+        return;
+      }
+      if (!items.some((m) => m.id === activeMessage)) activeMessage = items[0].id;
+      listEl.innerHTML = items.map((msg) => `<button class="inbox-item ${msg.id === activeMessage ? "active" : ""}" data-id="${msg.id}"><b>${msg.subject}</b><small>${msg.from}</small><small>${msg.timestamp}</small></button>`).join("");
+      drawDetail();
+    }
+
+    function drawDetail() {
+      const msg = state.inboxMessages.find((item) => item.id === activeMessage);
+      if (!msg) return;
+      detailEl.innerHTML = `
+        <article>
+          <h3>${msg.subject}</h3>
+          <p><b>From:</b> ${msg.from}<br/><b>Folder:</b> ${msg.folder}<br/><b>Time:</b> ${msg.timestamp}</p>
+          <pre class="mail-body">${msg.body}</pre>
+          <div class="badges">${(msg.links || []).map((l) => `<button class="link-btn" data-link="${l}">${l}</button>`).join("")}</div>
+        </article>`;
+      addActivity("mail-open", `${msg.folder}: ${msg.subject}`);
+    }
+
+    function saveDraft() {
+      const subject = prompt("Draft subject", "Draft note");
+      if (!subject) return;
+      const body = prompt("Draft body", "");
+      const draft = {
+        id: `draft-${Date.now()}`,
+        folder: "Drafts",
+        from: "you@devskits.os",
+        subject,
+        body: body || "",
+        timestamp: new Date().toLocaleString(),
+        links: []
+      };
+      const messages = [draft, ...state.inboxMessages];
+      setInboxMessages(messages);
+      setInboxDrafts([draft, ...state.inboxDrafts].slice(0, 20));
+      activeFolder = "Drafts";
+      activeMessage = draft.id;
+      drawFolders();
+      drawList();
+      window.DevSkitsDesktop.notify("Draft saved in Inbox");
+      addActivity("mail-draft", subject);
+    }
+
+    folderEl.addEventListener("click", (e) => {
+      const folder = e.target.closest("[data-folder]")?.dataset.folder;
+      if (!folder) return;
+      activeFolder = folder;
+      activeMessage = byFolder(folder)[0]?.id;
+      drawFolders();
+      drawList();
+    });
+
+    listEl.addEventListener("click", (e) => {
+      const id = e.target.closest("[data-id]")?.dataset.id;
+      if (!id) return;
+      activeMessage = id;
+      drawList();
+    });
+
+    detailEl.addEventListener("click", (e) => {
+      const link = e.target.closest("[data-link]")?.dataset.link;
+      if (!link) return;
+      if (link.startsWith("devskits://")) window.DevSkitsWindowManager.openApp("browser", { url: link });
+      if (link.startsWith("app:")) window.DevSkitsWindowManager.openApp(link.replace("app:", ""));
+    });
+
+    container.querySelector("#compose-btn").addEventListener("click", saveDraft);
+    drawFolders();
+    drawList();
+  }
+
+  window.DevSkitsAppRegistry = window.DevSkitsAppRegistry || {};
+  window.DevSkitsAppRegistry.inbox = render;
+})();

--- a/js/core/state.js
+++ b/js/core/state.js
@@ -3,6 +3,9 @@
     terminal: { title: "Terminal", icon: ">_", category: "System" },
     files: { title: "Files", icon: "▣", category: "System" },
     settings: { title: "Settings", icon: "⚙", category: "System" },
+    browser: { title: "Navigator", icon: "◫", category: "Network" },
+    inbox: { title: "Inbox", icon: "✉", category: "Network" },
+    buildlog: { title: "Build Log", icon: "#", category: "System" },
     projects: { title: "Projects", icon: "⌘", category: "Dev" },
     notes: { title: "Notes", icon: "✎", category: "Dev" },
     links: { title: "Links", icon: "↗", category: "Network" },
@@ -12,16 +15,66 @@
     about: { title: "About", icon: "i", category: "System" }
   };
 
+  const STORAGE = {
+    termHistory: "devskits-term-history",
+    recentApps: "devskits-recent-apps",
+    iconPositions: "devskits-icon-positions",
+    notes: "devskits-notes-v2",
+    activity: "devskits-activity-v3",
+    inbox: "devskits-inbox-v3",
+    inboxDrafts: "devskits-inbox-drafts-v3",
+    browserHistory: "devskits-browser-history-v3",
+    packages: "devskits-packages-v3",
+    changelog: "devskits-changelog-v3"
+  };
+
+  const defaults = {
+    packages: [
+      { id: "retro-clock-pack", name: "Retro Clock Pack", installed: false, unlocks: ["browser:devskits://system-specs"] },
+      { id: "extra-wallpapers", name: "Extra Wallpapers", installed: false, unlocks: ["settings:wallpapers"] },
+      { id: "loki-archive", name: "Loki Archive", installed: false, unlocks: ["inbox:loki", "browser:devskits://loki"] },
+      { id: "devskits-labs", name: "DevSkits Labs", installed: false, unlocks: ["browser:devskits://labs"] },
+      { id: "classic-icons", name: "Classic Icons", installed: false, unlocks: ["desktop:icons"] }
+    ],
+    changelog: [
+      { id: "b100", build: "0.1.047", phase: "Phase 1", date: "2026-01-07 08:12", tags: ["shell", "feature"], note: "Boot sequence, desktop, windows, taskbar, start menu and base apps came online." },
+      { id: "b200", build: "0.2.131", phase: "Phase 2", date: "2026-02-18 22:41", tags: ["polish", "app", "fix"], note: "Themes, wallpapers, persistence, and shell quality upgrades stabilized the identity shell." },
+      { id: "b300", build: "0.3.005", phase: "Phase 3", date: "2026-03-03 13:09", tags: ["app", "feature", "shell"], note: "Navigator, Inbox, Build Log and shared state bridge introduced for cross-app systems." }
+    ],
+    inbox: [
+      { id: "sys-boot", folder: "System", from: "system@devskits.os", subject: "Welcome to DevSkits OS 2.0", body: "Identity shell initialized. Use Navigator to explore devskits://home and devskits://changelog.", timestamp: "2026-03-03 13:10", links: ["devskits://home", "devskits://changelog"] },
+      { id: "loki-status", folder: "Inbox", from: "loki@companion.local", subject: "Loki status report", body: "Companion telemetry normal. Favorite zones: /projects and /notes. Requesting additional archive space.", timestamp: "2026-03-04 09:17", links: ["devskits://loki", "app:projects"] },
+      { id: "build-notes", folder: "Inbox", from: "builder@devskits.os", subject: "Build 0.3 patch notes", body: "Navigator internal pages now route through the shared state layer. Build Log app now tracks live history entries.", timestamp: "2026-03-04 22:06", links: ["app:buildlog", "devskits://projects"] },
+      { id: "support", folder: "Archive", from: "support@devskits.os", subject: "Support + donation channels", body: "Thanks for supporting the lab. Donation links are mirrored in Navigator and the Donate app.", timestamp: "2026-03-05 11:45", links: ["devskits://donate", "app:donate"] },
+      { id: "ideas", folder: "Drafts", from: "you@devskits.os", subject: "Unfinished project ideas", body: "- terminal profile cards\n- app package unlock cinematic text\n- loki gallery placeholders", timestamp: "2026-03-05 12:02", links: ["app:notes"] }
+    ]
+  };
+
+  function loadJSON(key, fallback) {
+    try {
+      const raw = localStorage.getItem(key);
+      return raw ? JSON.parse(raw) : fallback;
+    } catch (e) {
+      return fallback;
+    }
+  }
+
   const state = {
     windows: new Map(),
     z: 10,
     themes: ["default", "graphite", "paper"],
     activeTheme: localStorage.getItem("devskits-theme") || "default",
-    terminalHistory: JSON.parse(localStorage.getItem("devskits-term-history") || "[]"),
-    recentApps: JSON.parse(localStorage.getItem("devskits-recent-apps") || "[]"),
-    iconPositions: JSON.parse(localStorage.getItem("devskits-icon-positions") || "{}"),
+    terminalHistory: loadJSON(STORAGE.termHistory, []),
+    recentApps: loadJSON(STORAGE.recentApps, []),
+    iconPositions: loadJSON(STORAGE.iconPositions, {}),
     crt: localStorage.getItem("devskits-crt") !== "off",
-    wallpaper: localStorage.getItem("devskits-wallpaper") || "default"
+    wallpaper: localStorage.getItem("devskits-wallpaper") || "default",
+    activity: loadJSON(STORAGE.activity, []),
+    inboxMessages: loadJSON(STORAGE.inbox, defaults.inbox),
+    inboxDrafts: loadJSON(STORAGE.inboxDrafts, []),
+    browserHistory: loadJSON(STORAGE.browserHistory, []),
+    packages: loadJSON(STORAGE.packages, defaults.packages),
+    changelogEntries: loadJSON(STORAGE.changelog, defaults.changelog)
   };
 
   const ui = {
@@ -31,9 +84,76 @@
     taskButtons: document.querySelector("#task-buttons")
   };
 
+  const listeners = new Map();
+
   function saveState(key, value) {
     localStorage.setItem(key, JSON.stringify(value));
   }
 
-  window.DevSkitsState = { APPS, state, ui, saveState };
+  function emit(event, payload) {
+    (listeners.get(event) || []).forEach((fn) => fn(payload));
+  }
+
+  function on(event, handler) {
+    const items = listeners.get(event) || [];
+    items.push(handler);
+    listeners.set(event, items);
+    return () => listeners.set(event, (listeners.get(event) || []).filter((fn) => fn !== handler));
+  }
+
+  function addActivity(type, detail) {
+    const entry = { id: `a-${Date.now()}`, type, detail, at: new Date().toISOString() };
+    state.activity = [entry, ...state.activity].slice(0, 40);
+    saveState(STORAGE.activity, state.activity);
+    emit("activity", entry);
+    return entry;
+  }
+
+  function setInboxMessages(messages) {
+    state.inboxMessages = messages;
+    saveState(STORAGE.inbox, messages);
+    emit("state:inboxMessages", messages);
+  }
+
+  function setInboxDrafts(drafts) {
+    state.inboxDrafts = drafts;
+    saveState(STORAGE.inboxDrafts, drafts);
+    emit("state:inboxDrafts", drafts);
+  }
+
+  function setBrowserHistory(history) {
+    state.browserHistory = history;
+    saveState(STORAGE.browserHistory, history);
+    emit("state:browserHistory", history);
+  }
+
+  function setChangelogEntries(entries) {
+    state.changelogEntries = entries;
+    saveState(STORAGE.changelog, entries);
+    emit("state:changelogEntries", entries);
+  }
+
+  function setPackages(packages) {
+    state.packages = packages;
+    saveState(STORAGE.packages, packages);
+    emit("state:packages", packages);
+  }
+
+
+  window.DevSkitsState = {
+    APPS,
+    STORAGE,
+    defaults,
+    state,
+    ui,
+    saveState,
+    on,
+    emit,
+    addActivity,
+    setInboxMessages,
+    setInboxDrafts,
+    setBrowserHistory,
+    setChangelogEntries,
+    setPackages
+  };
 })();

--- a/js/core/terminal-engine.js
+++ b/js/core/terminal-engine.js
@@ -5,8 +5,18 @@
   function createTerminalEngine(print) {
     let cwd = "C:\\DEVSKITS";
 
+    const helpText = {
+      help: "help [command] - list commands or command help",
+      run: "run <app> - launch app by id/name",
+      open: "open <app|path|devskits://url> - open file, app, or internal browser url",
+      mail: "mail - open Inbox",
+      browser: "browser [url] - open Navigator",
+      changelog: "changelog - open Build Log",
+      recent: "recent - show tracked activity"
+    };
+
     const commands = {
-      help: () => "Commands: help clear cls about contact donate links projects loki github date whoami reboot theme ls dir cd pwd cat open echo ver hostname settings",
+      help: (_, cmd) => (cmd ? helpText[cmd] || `No extended help for ${cmd}` : `Commands: ${Object.keys(commands).join(" ")}`),
       clear: () => ({ clear: true }),
       cls: () => ({ clear: true }),
       about: () => "DevSkits OS 2.0 identity shell. Retro browser desktop.",
@@ -27,10 +37,37 @@
       cat: (_, arg) => catFile(arg),
       open: (_, arg) => openTarget(arg),
       echo: (_, ...args) => args.join(" "),
-      ver: () => "DevSkits OS 2.0 / Build 2026.02",
+      ver: () => "DevSkits OS 2.0 / Build 2026.03",
       hostname: () => "DEVSKITS-STATION",
-      settings: () => "Opening Settings app..."
+      settings: () => "Opening Settings app...",
+      run: (_, ...args) => runApp(args.join(" ")),
+      apps: () => Object.keys(window.DevSkitsState.APPS).join("\n"),
+      history: () => state.terminalHistory.join("\n") || "No terminal history.",
+      mail: () => "Opening Inbox...",
+      browser: (_, arg) => {
+        const target = arg || "devskits://home";
+        window.DevSkitsWindowManager.openApp("browser", { url: target });
+        return `Navigator -> ${target}`;
+      },
+      changelog: () => "Opening Build Log...",
+      pkg: () => state.packages.map((p) => `${p.installed ? "[x]" : "[ ]"} ${p.name}`).join("\n"),
+      recent: () => state.activity.slice(0, 12).map((a) => `${new Date(a.at).toLocaleTimeString()} ${a.type}: ${a.detail}`).join("\n") || "No activity yet.",
+      notify: (_, ...args) => {
+        const msg = args.join(" ") || "DevSkits ping";
+        window.DevSkitsDesktop.notify(msg);
+        return `Notified: ${msg}`;
+      }
     };
+
+    function runApp(name = "") {
+      if (!name) return "Usage: run <app>";
+      const normalized = name.toLowerCase();
+      const alias = { navigator: "browser", inbox: "inbox", buildlog: "buildlog" };
+      const appId = window.DevSkitsAppRegistry[normalized] ? normalized : alias[normalized];
+      if (!appId) return `Unknown app: ${name}`;
+      window.DevSkitsWindowManager.openApp(appId);
+      return `Launched ${appId}`;
+    }
 
     function listDir(arg = ".") {
       const path = FS.normalize(arg, cwd);
@@ -56,8 +93,12 @@
     }
 
     function openTarget(arg = "") {
-      if (!arg) return "Usage: open <app-or-file>";
+      if (!arg) return "Usage: open <app-or-file-or-url>";
       const lower = arg.toLowerCase();
+      if (lower.startsWith("devskits://")) {
+        window.DevSkitsWindowManager.openApp("browser", { url: lower });
+        return `Opened ${lower}`;
+      }
       if (window.DevSkitsAppRegistry[lower]) {
         window.DevSkitsWindowManager.openApp(lower);
         return `Opened ${lower}`;
@@ -85,7 +126,10 @@
       if (cmd === "github") window.open("https://github.com/DevSkits916", "_blank", "noopener");
       if (cmd === "theme") window.DevSkitsDesktop.cycleTheme();
       if (cmd === "reboot") setTimeout(window.DevSkitsDesktop.rebootSystem, 300);
-      if (["contact", "donate", "links", "projects", "loki", "settings"].includes(cmd)) window.DevSkitsWindowManager.openApp(cmd);
+      if (["contact", "donate", "links", "projects", "loki", "settings", "mail", "changelog"].includes(cmd)) {
+        const map = { mail: "inbox", changelog: "buildlog" };
+        window.DevSkitsWindowManager.openApp(map[cmd] || cmd);
+      }
       return result;
     }
 

--- a/js/core/window-manager.js
+++ b/js/core/window-manager.js
@@ -1,5 +1,5 @@
 (() => {
-  const { state, ui, APPS } = window.DevSkitsState;
+  const { state, ui, APPS, addActivity } = window.DevSkitsState;
 
   function persistSession() {
     const session = [];
@@ -186,6 +186,16 @@
     if (state.windows.has(appId)) {
       restoreWindow(appId);
       focusWindow(appId);
+      if (options?.url && appId === "browser" && window.DevSkitsBrowser) {
+        const rec = state.windows.get(appId);
+        const view = rec?.el.querySelector(".browser-view");
+        const addr = rec?.el.querySelector(".browser-address");
+        const result = window.DevSkitsBrowser.openUrl(options.url);
+        if (result && !result.external && view && addr) {
+          view.innerHTML = result.html;
+          addr.value = result.url;
+        }
+      }
       return;
     }
 
@@ -206,8 +216,9 @@
     render(win.querySelector(".window-content"), options);
     focusWindow(appId);
 
-    state.recentApps = [appId, ...state.recentApps.filter((id) => id !== appId)].slice(0, 5);
+    state.recentApps = [appId, ...state.recentApps.filter((id) => id !== appId)].slice(0, 8);
     localStorage.setItem("devskits-recent-apps", JSON.stringify(state.recentApps));
+    addActivity("open-app", APPS[appId].title);
     persistSession();
   }
 

--- a/style.css
+++ b/style.css
@@ -77,3 +77,31 @@ body { margin:0; height:100vh; font-family:"Lucida Console","Courier New",monosp
   .notes-shell, .files-shell { grid-template-columns:1fr; }
   .info-row { grid-template-columns:1fr; }
 }
+
+.browser-shell, .buildlog-shell { display:grid; gap:.45rem; height:100%; }
+.browser-toolbar { display:grid; grid-template-columns:auto auto auto 1fr auto; gap:.3rem; }
+.browser-address { border:2px inset #999; padding:.25rem; font-family:inherit; }
+.browser-view { border:2px inset #999; background:#fff; padding:.6rem; overflow:auto; }
+.retro-web-page { border:2px solid #222; padding:.55rem; background:repeating-linear-gradient(180deg,#f8f8f8,#f8f8f8 20px,#f0f0f0 20px,#f0f0f0 40px); min-height:100%; }
+.retro-web-page h2 { margin-top:0; border-bottom:1px dashed #777; padding-bottom:.25rem; }
+.retro-web-page ul, .retro-web-page ol { padding-left:1.2rem; }
+
+.inbox-shell { display:grid; grid-template-columns:150px 1fr 1.2fr; gap:.45rem; height:100%; }
+.inbox-folders, .inbox-list, .inbox-detail { border:2px inset #999; padding:.35rem; overflow:auto; }
+.inbox-folders, .inbox-list { display:grid; gap:.25rem; align-content:start; }
+.inbox-controls { margin-bottom:.35rem; }
+.inbox-item { border:2px outset #aaa; background:#ececec; text-align:left; padding:.3rem; display:grid; }
+.inbox-item.active { border-style:inset; }
+.mail-body { white-space:pre-wrap; background:#fafafa; border:1px solid #bbb; padding:.45rem; min-height:120px; }
+.inbox-placeholder, .inbox-empty { opacity:.7; }
+
+.buildlog-tools { display:flex; gap:.45rem; flex-wrap:wrap; }
+.buildlog-timeline .build-entry { border-left:3px solid #222; padding-left:.55rem; margin:.2rem 0 .55rem; }
+.buildlog-list .build-entry { border:2px groove #aaa; padding:.45rem; margin-bottom:.45rem; background:#fff; }
+.build-entry header { display:flex; justify-content:space-between; gap:.4rem; }
+
+@media (max-width: 780px) {
+  .browser-toolbar { grid-template-columns:1fr 1fr 1fr; }
+  .browser-address { grid-column:1 / -1; }
+  .inbox-shell { grid-template-columns:1fr; }
+}


### PR DESCRIPTION
### Motivation

- Provide the Phase 3 foundation for cross-app systems by introducing a shared state layer that stores and syncs activity, inbox, browser history, packages, and changelog data.
- Add core Phase 3 apps (retro in-OS browser, mail client, and build log) so the desktop feels like an interconnected pseudo-OS without changing the existing retro monochrome identity.
- Wire basic cross-app flows (deep links, terminal commands, activity tracking) so later Phase 3 features (installer, media, run dialog, etc.) can be layered on the same foundation.

### Description

- Extended the global state to include persistent Phase 3 datasets and mutation helpers in `js/core/state.js`, added `STORAGE` keys, seeded `defaults` (packages, changelog, inbox), and provided `on`/`emit`/`addActivity` and setters (`setInboxMessages`, `setInboxDrafts`, `setBrowserHistory`, `setChangelogEntries`, `setPackages`).
- Added a retro internal browser `Navigator` in `js/apps/browser.js` implementing `devskits://` routes, internal page templates (home/projects/contact/donate/loki/about/changelog/system-specs/packages/notes/labs), back/forward/reload/go controls, internal history recording, and safe passthrough for external `http(s)` links.
- Added an `Inbox` app in `js/apps/inbox.js` with classic folder sidebar (`Inbox`, `Sent`, `Drafts`, `Archive`, `System`), seeded system/lore messages, message detail pane with in-body deep links (internal `devskits://` and `app:` handoff), and draft composition persisted to local storage.
- Added a `Build Log` app in `js/apps/buildlog.js` with timeline/list views, tag filtering, and a deep-link button that opens Navigator on the changelog page.
- Integrated apps into the shell: registered new apps with `DevSkitsAppRegistry`, wired new scripts into `index.html`, added retro-safe UI styles in `style.css`, and updated `js/core/window-manager.js` to support opening the Browser with a URL and to record `open-app` activity (also extended `recentApps`).
- Expanded the terminal surface in `js/core/terminal-engine.js` to support Phase 3 commands (`run`, `apps`, `history`, `mail`, `browser`, `changelog`, `pkg`, `recent`, `notify`, `help <command>`) and to open `devskits://` URLs via `open`/`browser` commands.

### Testing

- Performed static JS syntax checks with `node --check` across `app.js`, `js/core/*.js`, `js/apps/*.js`, and `js/data/*.js`, which completed successfully.
- Launched a static server (`python3 -m http.server 4173`) and ran an automated Playwright-based UI exercise that boots the desktop, opens Navigator and navigates to an internal page, opens Inbox, and produced a verification screenshot (`artifacts/phase3-foundation.png`), confirming interactive flows and rendering succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b44b191a50832d9ff23501583db33c)