### PR TITLE
Replace Cash App with Chime and update branding to DevSkits 3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 https://devskits916.github.io/DevSkits-OS-2.0/
-# DevSkits OS 2.0
+# DevSkits 3.1
 
 A browser-based retro desktop experience built as a personal digital identity hub for **Travis Ramsey / DevSkits**.
 
-**DevSkits OS 2.0** mixes a vintage Windows-style shell with monochrome terminal aesthetics, draggable windows, a working command-line app, and built-in panels for projects, contact info, links, notes, donations, and Loki.
+**DevSkits 3.1** mixes a vintage Windows-style shell with monochrome terminal aesthetics, draggable windows, a working command-line app, and built-in panels for projects, contact info, links, notes, donations, and Loki.
 
 ## Live Demo
 
-[View DevSkits OS 2.0](https://devskits916.github.io/DevSkits-OS-2.0/)
+[View DevSkits 3.1](https://devskits916.github.io/DevSkits-OS-2.0/)
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>DevSkits OS 2.0</title>
+  <title>DevSkits 3.1</title>
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
@@ -16,7 +16,7 @@
 ██████╔╝███████╗ ╚████╔╝ ███████║██║  ██╗██║   ██║   ███████║
 ╚═════╝ ╚══════╝  ╚═══╝  ╚══════╝╚═╝  ╚═╝╚═╝   ╚═╝   ╚══════╝
       </pre>
-      <h1>DevSkits OS 2.0</h1>
+      <h1>DevSkits 3.1</h1>
       <p id="boot-status">Initializing identity shell...</p>
       <div class="boot-progress"><span id="boot-bar"></span></div>
     </div>

--- a/js/apps/about.js
+++ b/js/apps/about.js
@@ -1,6 +1,6 @@
 (() => {
   function render(container) {
-    container.innerHTML = `<h3>About DevSkits OS 2.0</h3><div class="app-grid"><div class="project-card"><strong>OS Name</strong><p>DevSkits OS 2.0</p></div><div class="project-card"><strong>Shell</strong><p>Retro Web Desktop Shell</p></div><div class="project-card"><strong>Build</strong><p>2026.02</p></div><div class="project-card"><strong>Runtime</strong><p>Browser / Vanilla JS</p></div><div class="project-card"><strong>Host</strong><p>${location.host || "localhost"}</p></div><div class="project-card"><strong>Status</strong><p>Stable-ish and expanding.</p></div></div>`;
+    container.innerHTML = `<h3>About DevSkits 3.1</h3><div class="app-grid"><div class="project-card"><strong>OS Name</strong><p>DevSkits 3.1</p></div><div class="project-card"><strong>Shell</strong><p>Retro Web Desktop Shell</p></div><div class="project-card"><strong>Build</strong><p>2026.02</p></div><div class="project-card"><strong>Runtime</strong><p>Browser / Vanilla JS</p></div><div class="project-card"><strong>Host</strong><p>${location.host || "localhost"}</p></div><div class="project-card"><strong>Status</strong><p>Stable-ish and expanding.</p></div></div>`;
   }
   window.DevSkitsAppRegistry = window.DevSkitsAppRegistry || {};
   window.DevSkitsAppRegistry.about = render;

--- a/js/apps/donate.js
+++ b/js/apps/donate.js
@@ -3,7 +3,7 @@
     const items = [
       ["GoFundMe", "https://gofund.me/6bbc0274e", "Community support campaign"],
       ["Venmo", "https://venmo.com/u/DevSkits", "Fast direct support"],
-      ["Cash App", "https://cash.app/$DevSkits916", "Quick utility donations"]
+      ["Chime", "https://chime.com", "Quick utility donations"]
     ];
     container.innerHTML = `<h3>Support DevSkits</h3><div class="app-grid">${items.map(([n, u, d]) => `<article class="project-card"><strong>${n}</strong><p>${d}</p><div class="badges"><button class="link-btn" data-url="${u}">Open</button><span class="tag">QR</span></div></article>`).join("")}</div>`;
     container.querySelectorAll(".link-btn").forEach((btn) => btn.addEventListener("click", () => window.open(btn.dataset.url, "_blank", "noopener")));

--- a/js/core/terminal-engine.js
+++ b/js/core/terminal-engine.js
@@ -9,7 +9,7 @@
       help: () => "Commands: help clear cls about contact donate links projects loki github date whoami reboot theme ls dir cd pwd cat open echo ver hostname settings",
       clear: () => ({ clear: true }),
       cls: () => ({ clear: true }),
-      about: () => "DevSkits OS 2.0 identity shell. Retro browser desktop.",
+      about: () => "DevSkits 3.1 identity shell. Retro browser desktop.",
       contact: () => "Opening Contact app...",
       donate: () => "Opening Donate app...",
       links: () => "Opening Links app...",
@@ -27,7 +27,7 @@
       cat: (_, arg) => catFile(arg),
       open: (_, arg) => openTarget(arg),
       echo: (_, ...args) => args.join(" "),
-      ver: () => "DevSkits OS 2.0 / Build 2026.02",
+      ver: () => "DevSkits 3.1 / Build 2026.02",
       hostname: () => "DEVSKITS-STATION",
       settings: () => "Opening Settings app..."
     };

--- a/js/core/window-manager.js
+++ b/js/core/window-manager.js
@@ -192,7 +192,7 @@
     const win = document.querySelector("#window-template").content.firstElementChild.cloneNode(true);
     const meta = APPS[appId];
     win.dataset.app = appId;
-    win.querySelector(".window-title").textContent = `${meta.title} - DevSkits OS 2.0`;
+    win.querySelector(".window-title").textContent = `${meta.title} - DevSkits 3.1`;
     win.style.left = `${Math.min(80 + state.windows.size * 22, window.innerWidth - 360)}px`;
     win.style.top = `${Math.min(70 + state.windows.size * 18, window.innerHeight - 260)}px`;
     win.style.zIndex = ++state.z;

--- a/js/data/filesystem.js
+++ b/js/data/filesystem.js
@@ -10,7 +10,7 @@
               type: "dir",
               children: {
                 "roadmap.txt": { type: "file", content: "DevSkits OS Roadmap\n- Shell polish\n- Deep app ecosystem\n- Better file integration" },
-                "devskits-os.project": { type: "project", ref: "DevSkits OS 2.0" }
+                "devskits-os.project": { type: "project", ref: "DevSkits 3.1" }
               }
             },
             CONTACT: {

--- a/js/data/projects.js
+++ b/js/data/projects.js
@@ -1,5 +1,5 @@
 window.DevSkitsProjects = [
-  { name: "DevSkits OS 2.0", desc: "Retro browser desktop identity shell.", status: "active", tags: ["web", "terminal"] },
+  { name: "DevSkits 3.1", desc: "Retro browser desktop identity shell.", status: "active", tags: ["web", "terminal"] },
   { name: "Paste Happy Studio", desc: "Snippet utility for fast workflows.", status: "building", tags: ["utility", "web"] },
   { name: "Terminal Portfolio Generator", desc: "CLI-style portfolio scaffolder.", status: "building", tags: ["terminal", "utility"] },
   { name: "LokiMon", desc: "Companion tracking concept.", status: "concept", tags: ["concept"] },


### PR DESCRIPTION
### Motivation
- Update public-facing donation information and bump the project branding to the next patch identity without changing behavior or visual style.
- Keep all visible and programmatic OS identifiers consistent with the new release while preserving the existing retro UI and app behavior.

### Description
- Replaced the `Cash App` donation entry with `Chime` and updated its URL in `js/apps/donate.js` to `https://chime.com` while keeping the same UI/interaction pattern.
- Renamed visible product branding and internal identity strings from `DevSkits OS 2.0` to `DevSkits 3.1` across UI and metadata in `index.html`, `README.md`, `js/apps/about.js`, `js/core/window-manager.js`, `js/core/terminal-engine.js`, `js/data/projects.js`, and `js/data/filesystem.js`.
- Ensured window title suffix, terminal `about`/`ver` responses, project listing, and virtual filesystem project ref are synchronized to the new name.
- No UI structure, layout, or existing app behaviors were altered beyond the branding and donate-link update.

### Testing
- Searched the codebase with `rg` to confirm there are no remaining references to `Cash App`, `cash.app`, or the old `DevSkits OS 2.0` strings and confirmed replacements succeeded.
- Launched a local static server with `python -m http.server` and loaded the site to verify core assets served (HTTP 200) and the boot/home header reflects `DevSkits 3.1` and captured a screenshot for visual verification.
- Inspected `js/apps/donate.js` to confirm the donate card now references `https://chime.com` and that the donate card rendering behavior (open-in-new-tab) remains unchanged.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b44d6b8044832db95f3a414ffe57d1)