### PR TITLE
Add local DevSkits 3.1 branding and inline SVG icon registry; clean tray to clock-only

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,13 +9,7 @@
 <body>
   <div id="boot-screen" class="boot-screen" aria-live="polite">
     <div class="boot-panel">
-      <pre class="boot-logo">██████╗ ███████╗██╗   ██╗███████╗██╗  ██╗██╗████████╗███████╗
-██╔══██╗██╔════╝██║   ██║██╔════╝██║ ██╔╝██║╚══██╔══╝██╔════╝
-██║  ██║█████╗  ██║   ██║███████╗█████╔╝ ██║   ██║   ███████╗
-██║  ██║██╔══╝  ╚██╗ ██╔╝╚════██║██╔═██╗ ██║   ██║   ╚════██║
-██████╔╝███████╗ ╚████╔╝ ███████║██║  ██╗██║   ██║   ███████║
-╚═════╝ ╚══════╝  ╚═══╝  ╚══════╝╚═╝  ╚═╝╚═╝   ╚═╝   ╚══════╝
-      </pre>
+      <div id="boot-logo" class="boot-logo" aria-label="DevSkits 3.1 boot logo"></div>
       <h1>DevSkits 3.1</h1>
       <p id="boot-status">Initializing identity shell...</p>
       <div class="boot-progress"><span id="boot-bar"></span></div>
@@ -23,6 +17,7 @@
   </div>
 
   <div id="desktop" class="desktop hidden" role="application" aria-label="DevSkits Desktop">
+    <div id="desktop-brandmark" class="desktop-brandmark" aria-hidden="true"></div>
     <div class="scanlines"></div>
     <div id="desktop-icons" class="desktop-icons"></div>
     <div id="window-layer" class="window-layer"></div>
@@ -71,7 +66,6 @@
       <button id="start-btn" class="start-btn" aria-expanded="false">DevSkits</button>
       <div id="task-buttons" class="task-buttons" aria-label="Open windows"></div>
       <div class="system-tray">
-        <span class="tray-label">SYS</span>
         <time id="clock"></time>
       </div>
     </footer>
@@ -101,6 +95,7 @@
 
   <script src="js/data/projects.js"></script>
   <script src="js/data/filesystem.js"></script>
+  <script src="js/core/branding.js"></script>
   <script src="js/core/state.js"></script>
   <script src="js/core/world.js"></script>
   <script src="js/core/terminal-engine.js"></script>

--- a/js/apps/contact.js
+++ b/js/apps/contact.js
@@ -1,17 +1,30 @@
 (() => {
-  function toLink(v) {
-    if (v.startsWith("http")) return `<a href="${v}" target="_blank" rel="noopener">${v}</a>`;
-    if (v.includes("@")) return `<a href="mailto:${v}">${v}</a>`;
-    return v;
+  const icon = (name, label) => window.DevSkitsBranding.icon(name, "brand-icon", label);
+
+  function toLink(value, type) {
+    if (type === "email") return `<a href="mailto:${value}">${value}</a>`;
+    if (type === "phone") return `<a href="tel:${value}">${value}</a>`;
+    if (type === "url") return `<a href="${value}" target="_blank" rel="noopener">${value}</a>`;
+    return value;
   }
+
   function render(container) {
-    const rows = [["Name", "Travis Ramsey"], ["Brand", "DevSkits"], ["Email", "DevSkits@icloud.com"], ["Phone", "916-420-3052"], ["GitHub", "https://github.com/DevSkits916"]];
-    container.innerHTML = `<div class="app-grid">${rows.map(([k, v]) => `<div class="info-row"><strong>${k}</strong><span>${toLink(v)}</span><button class="copy-btn" data-copy="${v}">Copy</button></div>`).join("")}<button class="link-btn" id="vcard-download">Download vCard</button></div>`;
+    const rows = [
+      ["person", "Name", "Travis Ramsey", "text"],
+      ["person", "Brand", "DevSkits", "text"],
+      ["email", "Email", "DevSkits@icloud.com", "email"],
+      ["phone", "Phone", "916-420-3052", "phone"],
+      ["location", "Location", "Sacramento, CA", "text"],
+      ["github", "GitHub", "https://github.com/DevSkits916", "url"]
+    ];
+    container.innerHTML = `<div class="app-grid">${rows.map(([iconName, key, value, type]) => `<div class="info-row"><strong>${icon(iconName, key)}</strong><span>${toLink(value, type)}</span><button class="copy-btn icon-btn" data-copy="${value}">${icon("copy", "Copy")}</button></div>`).join("")}<button class="link-btn icon-btn" id="vcard-download">${icon("notes", "Download vCard")}</button></div>`;
+
     container.querySelectorAll(".copy-btn").forEach((btn) => btn.addEventListener("click", async () => {
       await navigator.clipboard.writeText(btn.dataset.copy).catch(() => {});
-      btn.textContent = "Copied";
-      setTimeout(() => (btn.textContent = "Copy"), 700);
+      btn.innerHTML = icon("copy", "Copied");
+      setTimeout(() => { btn.innerHTML = icon("copy", "Copy"); }, 700);
     }));
+
     container.querySelector("#vcard-download").addEventListener("click", () => {
       const data = "BEGIN:VCARD\nVERSION:3.0\nFN:Travis Ramsey\nEMAIL:DevSkits@icloud.com\nTEL:916-420-3052\nEND:VCARD";
       const a = document.createElement("a");
@@ -20,6 +33,7 @@
       a.click();
     });
   }
+
   window.DevSkitsAppRegistry = window.DevSkitsAppRegistry || {};
   window.DevSkitsAppRegistry.contact = render;
 })();

--- a/js/apps/donate.js
+++ b/js/apps/donate.js
@@ -1,13 +1,18 @@
 (() => {
+  const icon = (name, label) => window.DevSkitsBranding.icon(name, "brand-icon", label);
+
   function render(container) {
     const items = [
-      ["GoFundMe", "https://gofund.me/6bbc0274e", "Community support campaign"],
-      ["Venmo", "https://venmo.com/u/DevSkits", "Fast direct support"],
-      ["Chime", "https://chime.com", "Quick utility donations"]
+      ["GoFundMe", "https://gofund.me/6bbc0274e", "Community support campaign", "gofundme"],
+      ["Venmo", "https://venmo.com/u/DevSkits", "Fast direct support", "venmo"],
+      ["Cash App", "https://cash.app", "Simple peer-to-peer support", "cashapp"],
+      ["Chime", "https://chime.com", "Quick utility donations", "chime"],
+      ["PayPal", "https://paypal.com", "Card and account support", "paypal"]
     ];
-    container.innerHTML = `<h3>Support DevSkits</h3><div class="app-grid">${items.map(([n, u, d]) => `<article class="project-card"><strong>${n}</strong><p>${d}</p><div class="badges"><button class="link-btn" data-url="${u}">Open</button><span class="tag">QR</span></div></article>`).join("")}</div>`;
+    container.innerHTML = `<h3>${icon("document", "Support DevSkits")}</h3><div class="app-grid">${items.map(([name, url, description, iconName]) => `<article class="project-card"><strong>${icon(iconName, name)}</strong><p>${description}</p><div class="badges"><button class="link-btn icon-btn" data-url="${url}">${icon("external", "Open")}</button></div></article>`).join("")}</div>`;
     container.querySelectorAll(".link-btn").forEach((btn) => btn.addEventListener("click", () => window.open(btn.dataset.url, "_blank", "noopener")));
   }
+
   window.DevSkitsAppRegistry = window.DevSkitsAppRegistry || {};
   window.DevSkitsAppRegistry.donate = render;
 })();

--- a/js/apps/links.js
+++ b/js/apps/links.js
@@ -1,13 +1,20 @@
 (() => {
+  const icon = (name, label) => window.DevSkitsBranding.icon(name, "brand-icon", label);
+
   function render(container) {
     const groups = {
-      social: [["Facebook", "https://www.facebook.com/DevSkits?mibextid=wwXIfr"], ["Reddit", "https://www.reddit.com/u/DevSkits/s/RE9W0sZoV1"]],
-      support: [["GoFundMe", "https://gofund.me/6bbc0274e"]],
-      code: [["GitHub", "https://github.com/DevSkits916"]]
+      social: [
+        ["GitHub", "https://github.com/DevSkits916", "github"],
+        ["Facebook", "https://www.facebook.com/DevSkits?mibextid=wwXIfr", "facebook"],
+        ["Reddit", "https://www.reddit.com/u/DevSkits/s/RE9W0sZoV1", "reddit"],
+        ["X / Twitter", "https://x.com", "x"],
+        ["GoFundMe", "https://gofund.me/6bbc0274e", "gofundme"]
+      ]
     };
-    container.innerHTML = Object.entries(groups).map(([group, rows]) => `<h4>${group.toUpperCase()}</h4><div class="app-grid">${rows.map(([n, u]) => `<button class="link-btn" data-url="${u}">${n}</button>`).join("")}</div>`).join("");
+    container.innerHTML = Object.entries(groups).map(([group, rows]) => `<h4>${group.toUpperCase()}</h4><div class="app-grid">${rows.map(([name, url, iconName]) => `<button class="link-btn icon-btn" data-url="${url}">${icon(iconName, name)}${icon("external", "")}</button>`).join("")}</div>`).join("");
     container.querySelectorAll(".link-btn").forEach((b) => b.addEventListener("click", () => window.open(b.dataset.url, "_blank", "noopener")));
   }
+
   window.DevSkitsAppRegistry = window.DevSkitsAppRegistry || {};
   window.DevSkitsAppRegistry.links = render;
 })();

--- a/js/core/branding.js
+++ b/js/core/branding.js
@@ -1,0 +1,50 @@
+(() => {
+  const monoStroke = "currentColor";
+
+  const icons = {
+    github: `<svg viewBox="0 0 24 24" aria-hidden="true"><path fill="${monoStroke}" d="M12 .6a12 12 0 0 0-3.79 23.39c.6.12.82-.26.82-.58v-2.24c-3.34.72-4.04-1.41-4.04-1.41-.55-1.37-1.33-1.73-1.33-1.73-1.08-.74.08-.73.08-.73 1.2.09 1.83 1.23 1.83 1.23 1.06 1.83 2.79 1.3 3.47.99.11-.78.42-1.3.76-1.6-2.67-.3-5.48-1.33-5.48-5.94 0-1.31.46-2.38 1.23-3.22-.13-.3-.54-1.54.11-3.2 0 0 1-.32 3.3 1.23a11.4 11.4 0 0 1 6 0c2.3-1.55 3.3-1.23 3.3-1.23.66 1.66.24 2.9.12 3.2.76.84 1.23 1.9 1.23 3.22 0 4.62-2.82 5.64-5.5 5.94.44.37.82 1.08.82 2.19v3.24c0 .32.22.71.83.58A12 12 0 0 0 12 .6Z"/></svg>`,
+    facebook: `<svg viewBox="0 0 24 24" aria-hidden="true"><path fill="${monoStroke}" d="M13.7 22v-8.3h2.8l.42-3.24h-3.22V8.4c0-.94.27-1.57 1.62-1.57h1.72V3.95c-.84-.09-1.69-.13-2.54-.12-2.52 0-4.24 1.54-4.24 4.38v2.45H8v3.24h2.25V22h3.45Z"/></svg>`,
+    reddit: `<svg viewBox="0 0 24 24" aria-hidden="true"><path fill="${monoStroke}" d="M24 11.7a2.4 2.4 0 0 0-4.1-1.7 11.2 11.2 0 0 0-6.7-2.2l1.1-5 3.5.8a1.9 1.9 0 1 0 .4-1.5l-4-.9c-.4-.1-.7.2-.8.5L12.1 8A11.4 11.4 0 0 0 5 10.2 2.4 2.4 0 1 0 2.8 14v.3c0 4 4.2 7.3 9.3 7.3 5.1 0 9.3-3.3 9.3-7.3V14a2.4 2.4 0 0 0 2.6-2.3Zm-16.2 1.6a1.4 1.4 0 1 1 0-2.8 1.4 1.4 0 0 1 0 2.8Zm7.5 4.7c-.9.9-2.3 1.3-4.1 1.3-1.8 0-3.2-.4-4.1-1.3a.5.5 0 0 1 .7-.7c.7.7 1.8 1 3.4 1s2.7-.3 3.4-1a.5.5 0 1 1 .7.7Zm-.1-4.7a1.4 1.4 0 1 1 0-2.8 1.4 1.4 0 0 1 0 2.8Z"/></svg>`,
+    x: `<svg viewBox="0 0 24 24" aria-hidden="true"><path fill="${monoStroke}" d="M18.9 2h3.7l-8.1 9.3L24 22h-7.5l-5.8-7-6 7H1l8.6-10L0 2h7.7l5.3 6.4L18.9 2Zm-1.3 17.8h2L6.6 4.1h-2l13 15.7Z"/></svg>`,
+    gofundme: `<svg viewBox="0 0 24 24" aria-hidden="true"><path fill="${monoStroke}" d="M12 2c4.8 0 8.8 3.4 9.8 8h-2.7a7.1 7.1 0 0 0-13.8 0H2.2A10.1 10.1 0 0 1 12 2Zm0 20a10 10 0 0 1-9.8-8h2.7a7.1 7.1 0 0 0 13.8 0h3A10 10 0 0 1 12 22Zm-3.4-6.6V8.7h4.8a2.8 2.8 0 1 1 0 5.5h-2.4v1.2H8.6Zm2.4-3.2h2.2a1 1 0 1 0 0-2h-2.2v2Z"/></svg>`,
+    venmo: `<svg viewBox="0 0 24 24" aria-hidden="true"><path fill="${monoStroke}" d="M18.8 3.6c.6 1 .9 2.1.9 3.3 0 5-4.2 11.4-7.6 15h-5L4.3 5.6h4.3l1.5 12c2-2.7 4.9-7.6 4.9-10.7 0-1.2-.3-2-.8-2.8l4.6-.5Z"/></svg>`,
+    cashapp: `<svg viewBox="0 0 24 24" aria-hidden="true"><path fill="${monoStroke}" d="M14.7 3.2h-2.8l-.7 2.3c-2.6.3-4.5 2-4.5 4.3 0 2.7 2.4 3.8 4.6 4.6l-1 3.4c-1.5-.5-2.8-1.4-3.8-2.3l-1.8 2.5c1.4 1.2 3.3 2.2 5 2.6l-.6 2.2h2.8l.6-2.2c2.8-.3 4.9-2.1 4.9-4.6 0-2.8-2.3-4-4.8-4.9l1-3.2c1.1.4 2 .9 2.9 1.7l1.7-2.4a9.5 9.5 0 0 0-4-2l.5-2Zm-2.7 7.5c-1-.4-1.8-.9-1.8-1.6 0-.7.6-1.2 1.6-1.4l-.8 3Zm.8 6 .9-3.3c1 .4 1.8.9 1.8 1.7s-.7 1.4-2 1.6h-.7Z"/></svg>`,
+    chime: `<svg viewBox="0 0 24 24" aria-hidden="true"><path fill="${monoStroke}" d="M12 1.8A10.2 10.2 0 1 0 22.2 12 10.2 10.2 0 0 0 12 1.8Zm0 2.4A7.8 7.8 0 1 1 4.2 12 7.8 7.8 0 0 1 12 4.2Zm3.8 11.3H9.2V8.6h2.3v4.8h4.3v2.1Z"/></svg>`,
+    paypal: `<svg viewBox="0 0 24 24" aria-hidden="true"><path fill="${monoStroke}" d="M7.2 3h8.1c2.8 0 4.8 2 4.3 4.8-.6 3.5-3 5.2-6.7 5.2h-2.4l-.8 4.8H5.9L7.2 3Zm2 2.3-.9 5.4h2.5c2.3 0 3.7-.8 4-2.8.3-1.8-.8-2.6-3.2-2.6H9.2Zm-3.2 8.1h2.9L8 21H5l1-7.6Z"/></svg>`,
+    email: `<svg viewBox="0 0 24 24" aria-hidden="true"><path fill="${monoStroke}" d="M2 5h20v14H2V5Zm2 2v1l8 5 8-5V7l-8 5-8-5Z"/></svg>`,
+    phone: `<svg viewBox="0 0 24 24" aria-hidden="true"><path fill="${monoStroke}" d="m6.6 2 3.2 3.2-1.8 2.7a15.6 15.6 0 0 0 8.1 8.1l2.7-1.8L22 17.4l-2.9 2.9c-.7.7-1.7 1-2.6.7A20.6 20.6 0 0 1 3 7.5c-.3-.9 0-1.9.7-2.6L6.6 2Z"/></svg>`,
+    person: `<svg viewBox="0 0 24 24" aria-hidden="true"><path fill="${monoStroke}" d="M12 12a5 5 0 1 0 0-10 5 5 0 0 0 0 10Zm0 2c-4.4 0-8 2.2-8 5v3h16v-3c0-2.8-3.6-5-8-5Z"/></svg>`,
+    location: `<svg viewBox="0 0 24 24" aria-hidden="true"><path fill="${monoStroke}" d="M12 2a7 7 0 0 0-7 7c0 5.1 7 13 7 13s7-7.9 7-13a7 7 0 0 0-7-7Zm0 10.2A3.2 3.2 0 1 1 12 5.8a3.2 3.2 0 0 1 0 6.4Z"/></svg>`,
+    external: `<svg viewBox="0 0 24 24" aria-hidden="true"><path fill="${monoStroke}" d="M14 3h7v7h-2V6.4l-7.3 7.3-1.4-1.4L17.6 5H14V3ZM5 5h6v2H7v10h10v-4h2v6H5V5Z"/></svg>`,
+    copy: `<svg viewBox="0 0 24 24" aria-hidden="true"><path fill="${monoStroke}" d="M8 8h12v14H8V8Zm-4-6h12v4H6v12H4V2Z"/></svg>`,
+    browser: `<svg viewBox="0 0 24 24" aria-hidden="true"><path fill="${monoStroke}" d="M2 4h20v16H2V4Zm2 4v10h16V8H4Zm2.8 2.3a1.3 1.3 0 1 0 0 2.6 1.3 1.3 0 0 0 0-2.6Z"/></svg>`,
+    notes: `<svg viewBox="0 0 24 24" aria-hidden="true"><path fill="${monoStroke}" d="M5 2h11l5 5v15H5V2Zm10 1.8V8h4.2L15 3.8ZM8 11h8v1.8H8V11Zm0 4h8v1.8H8V15Z"/></svg>`,
+    document: `<svg viewBox="0 0 24 24" aria-hidden="true"><path fill="${monoStroke}" d="M6 2h9l5 5v15H6V2Zm8 2v4h4l-4-4Z"/></svg>`
+  };
+
+  const logos = {
+    devskits31: `<svg viewBox="0 0 520 220" role="img" aria-label="DevSkits 3.1 logo" xmlns="http://www.w3.org/2000/svg">
+      <rect x="0" y="0" width="520" height="220" fill="none"/>
+      <g fill="none" stroke="currentColor" stroke-width="4">
+        <path d="M54 170c28-56 70-94 123-108" opacity=".35"/>
+        <path d="M466 168c-11-58-53-104-131-116" opacity=".35"/>
+        <path d="M66 180h388" opacity=".45"/>
+      </g>
+      <text x="260" y="108" fill="currentColor" text-anchor="middle" font-size="76" font-weight="700" font-family="Georgia, 'Times New Roman', serif" letter-spacing="1.5">DevSkits</text>
+      <rect x="200" y="132" width="120" height="58" rx="12" fill="none" stroke="currentColor" stroke-width="4"/>
+      <text x="260" y="174" fill="currentColor" text-anchor="middle" font-size="48" font-weight="700" font-family="'Courier New', monospace">3.1</text>
+      <g transform="translate(42 28)" fill="none" stroke="currentColor" stroke-width="4">
+        <path d="M0 46h44l22-10v36H0z" opacity=".7"/>
+        <path d="M11 41V16h44v15" opacity=".7"/>
+        <path d="M27 16v31M42 16v26" opacity=".7"/>
+      </g>
+    </svg>`
+  };
+
+  function icon(name, cls = "brand-icon", label = "") {
+    const svg = icons[name] || icons.document;
+    return `<span class="${cls}" aria-hidden="true" data-icon="${name}">${svg}</span>${label ? `<span>${label}</span>` : ""}`;
+  }
+
+  window.DevSkitsBranding = { icons, logos, icon };
+})();

--- a/js/core/desktop.js
+++ b/js/core/desktop.js
@@ -29,6 +29,16 @@
     localStorage.setItem("devskits-crt", state.crt ? "on" : "off");
   }
 
+
+
+  function applyBranding() {
+    const logo = window.DevSkitsBranding?.logos?.devskits31 || "";
+    const bootLogo = document.querySelector("#boot-logo");
+    const desktopLogo = document.querySelector("#desktop-brandmark");
+    if (bootLogo) bootLogo.innerHTML = logo;
+    if (desktopLogo) desktopLogo.innerHTML = logo;
+  }
+
   function buildDesktopIcons() {
     const tpl = document.querySelector("#desktop-icon-template");
     ui.iconContainer.innerHTML = "";
@@ -50,27 +60,49 @@
 
   function wireIcon(node, entry) {
     let drag = null;
-    node.addEventListener("dblclick", () => {
+    let moved = false;
+    let clickTimer = null;
+
+    function openEntry() {
       if (!entry.isShortcut) window.DevSkitsWindowManager.openApp(entry.id);
       else if (entry.shortcut.type === "route") window.DevSkitsWindowManager.openApp("browser", { route: entry.shortcut.target });
       else window.DevSkitsWindowManager.openApp(entry.shortcut.target);
+    }
+
+    node.addEventListener("dblclick", (e) => {
+      e.preventDefault();
+      clearTimeout(clickTimer);
+      if (!moved) openEntry();
     });
+
+    node.addEventListener("click", () => {
+      clearTimeout(clickTimer);
+      if (moved) return;
+      clickTimer = setTimeout(() => openEntry(), 180);
+    });
+
     node.addEventListener("pointerdown", (e) => {
-      drag = { dx: e.offsetX, dy: e.offsetY };
+      moved = false;
+      drag = { dx: e.offsetX, dy: e.offsetY, startX: e.clientX, startY: e.clientY };
       node.setPointerCapture(e.pointerId);
     });
+
     node.addEventListener("pointermove", (e) => {
       if (!drag) return;
+      const shift = Math.abs(e.clientX - drag.startX) + Math.abs(e.clientY - drag.startY);
+      moved = moved || shift > 4;
       const x = Math.max(0, Math.min(e.clientX - drag.dx, window.innerWidth - 94));
       const y = Math.max(0, Math.min(e.clientY - drag.dy, window.innerHeight - 130));
       node.style.left = `${x}px`;
       node.style.top = `${y}px`;
     });
+
     node.addEventListener("pointerup", () => {
       if (!drag) return;
       state.iconPositions[entry.id] = { x: parseInt(node.style.left, 10), y: parseInt(node.style.top, 10) };
       localStorage.setItem("devskits-icon-positions", JSON.stringify(state.iconPositions));
       drag = null;
+      setTimeout(() => { moved = false; }, 0);
     });
   }
 
@@ -201,30 +233,6 @@
     });
   }
 
-  function renderWidgets() {
-    const bar = document.createElement("aside");
-    bar.className = "desktop-widgets";
-    ui.desktop.appendChild(bar);
-    setInterval(() => {
-      const settings = W().getAppSettings();
-      const packages = Object.values(W().getPackages()).filter(Boolean).length;
-      const recent = W().getRecentActivity().slice(0, 2).map((r) => `${r.type}: ${r.detail}`).join(" | ") || "none";
-      const proc = W().getProcessSnapshot();
-      const upd = W().getUpdates();
-      const rows = [];
-      if (settings.widgets.clock) rows.push(`<div class="widget">${new Date().toLocaleTimeString()} / Uptime ${(proc.uptimeMs / 60000) | 0}m</div>`);
-      if (settings.widgets.health) rows.push(`<div class="widget">CPU ${proc.cpu}% MEM ${proc.memory}%</div>`);
-      if (settings.widgets.updates) rows.push(`<div class="widget">Build ${upd.currentVersion} / ${upd.currentBuild}${upd.available.length ? ` · ${upd.available.length} update` : ""}</div>`);
-      if (settings.widgets.activity) rows.push(`<div class="widget">Recent ${recent.slice(0, 74)}</div>`);
-      rows.push(`<div class="widget">Packages ${packages}/5 · <button class="link-btn" data-quick="activity">Activity</button> <button class="link-btn" data-quick="updater">Updater</button></div>`);
-      bar.innerHTML = rows.join("");
-    }, 1200);
-    bar.addEventListener("click", (e) => {
-      const q = e.target.dataset.quick;
-      if (q) window.DevSkitsWindowManager.openApp(q);
-    });
-  }
-
   function initScreensaver() {
     const enabled = localStorage.getItem("devskits-screensaver") === "on";
     if (!enabled) return;
@@ -262,11 +270,11 @@
     applyTheme(state.activeTheme);
     applyWallpaper(state.wallpaper);
     toggleCRT(state.crt);
+    applyBranding();
     buildDesktopIcons();
     bindDesktopContextMenu();
     bindRunDialog();
     W().getSticky().forEach((s) => createSticky(s));
-    renderWidgets();
     initScreensaver();
     updateClock();
     setInterval(updateClock, 1000);

--- a/style.css
+++ b/style.css
@@ -15,20 +15,23 @@ body { margin:0; height:100vh; font-family:"Lucida Console","Courier New",monosp
 .hidden { display:none !important; }
 .boot-screen { position:fixed; inset:0; background:#000; color:#d0d0d0; display:grid; place-items:center; padding:1rem; }
 .boot-panel { width:min(760px,100%); border:2px solid #999; padding:1rem; background:#0c0c0c; box-shadow:0 0 0 2px #333; }
-.boot-logo { margin:0; font-size:clamp(0.38rem,1.2vw,0.74rem); line-height:1.1; color:#f5f5f5; overflow-x:auto; }
+.boot-logo { margin:0 auto .55rem; width:min(420px,92vw); color:#f5f5f5; }
+.boot-logo svg { width:100%; height:auto; display:block; }
 .boot-progress { height:18px; border:2px inset #666; background:#111; }
 .boot-progress span { display:block; height:100%; width:0; background:repeating-linear-gradient(90deg,#e5e5e5 0 7px,#9f9f9f 7px 14px); }
 .desktop { position:fixed; inset:0; background:radial-gradient(circle at 20% 15%,#d7d7d7,var(--bg)); }
+.desktop-brandmark { position:absolute; inset:8% 10% auto 10%; display:grid; place-items:center; opacity:.12; pointer-events:none; z-index:0; }
+.desktop-brandmark svg { width:min(920px,86vw); height:auto; }
 .desktop[data-wallpaper="grid"] { background-image: linear-gradient(#d8d8d8 1px, transparent 1px), linear-gradient(90deg, #d8d8d8 1px, transparent 1px); background-size: 16px 16px; }
 .desktop[data-wallpaper="noise"] { background-image: repeating-radial-gradient(#d4d4d4 0 1px, transparent 1px 2px); background-size: 3px 3px; }
 .desktop[data-wallpaper="fade"] { background: linear-gradient(180deg,#e4e4e4,var(--bg)); }
-.scanlines { pointer-events:none; position:absolute; inset:0; background:repeating-linear-gradient(to bottom, rgba(255,255,255,0.03) 0 1px, rgba(0,0,0,0.02) 2px 3px); }
-.desktop-icons { position:absolute; inset:0.5rem 0.5rem 3rem 0.5rem; }
+.scanlines { pointer-events:none; position:absolute; inset:0; z-index:1; background:repeating-linear-gradient(to bottom, rgba(255,255,255,0.03) 0 1px, rgba(0,0,0,0.02) 2px 3px); }
+.desktop-icons { position:absolute; inset:0.5rem 0.5rem 3rem 0.5rem; z-index:2; }
 .desktop-icon { width:90px; min-height:90px; border:1px solid transparent; background:transparent; display:flex; flex-direction:column; align-items:center; justify-content:center; color:var(--text); cursor:pointer; }
 .desktop-icon:hover { border-color:var(--border-dark); background:rgba(255,255,255,0.4); }
 .icon-glyph { width:36px; height:30px; border:2px outset #999; background:var(--panel); display:grid; place-items:center; }
 .icon-label { font-size:0.72rem; text-align:center; }
-.window-layer { position:absolute; inset:0 0 2.35rem 0; }
+.window-layer { position:absolute; inset:0 0 2.35rem 0; z-index:3; }
 .window { position:absolute; min-width:280px; min-height:180px; width:min(560px,92vw); height:min(380px,74vh); border:2px solid var(--border-dark); box-shadow:0 0 0 2px #fff inset, 3px 3px 0 rgba(0,0,0,0.35); background:var(--panel); display:flex; flex-direction:column; overflow:hidden; transition: transform .12s ease, opacity .12s ease; }
 .window.minimizing { transform:scale(0.92); opacity:0; }
 .window-titlebar { background:var(--title-bg); color:var(--title-color); padding:.22rem .35rem; display:flex; align-items:center; justify-content:space-between; cursor:move; user-select:none; }
@@ -41,7 +44,7 @@ body { margin:0; height:100vh; font-family:"Lucida Console","Courier New",monosp
 .task-buttons { flex:1; display:flex; gap:.2rem; overflow:auto; }
 .task-btn { min-width:100px; max-width:240px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
 .task-btn.active { border-style:inset; }
-.system-tray { display:flex; align-items:center; gap:.35rem; border:2px inset #eee; padding:.25rem .45rem; min-width:95px; }
+.system-tray { display:flex; align-items:center; border:2px inset #eee; padding:.25rem .45rem; min-width:78px; justify-content:center; }
 .start-menu { position:absolute; left:.2rem; bottom:2.5rem; width:min(320px,94vw); border:2px solid var(--border-dark); background:var(--panel); box-shadow:4px 4px 0 rgba(0,0,0,.3); padding:.4rem; display:grid; gap:.35rem; z-index:2600; }
 .start-header { background:var(--title-bg); color:var(--title-color); padding:.3rem; font-size:.75rem; }
 .start-search { border:2px inset #bbb; padding:.25rem; font-family:inherit; }
@@ -126,3 +129,7 @@ fieldset label { display:block; margin:.15rem 0; }
 @media (max-width: 780px) {
   .desktop-widgets { position:static; width:auto; margin:.35rem; }
 }
+
+.brand-icon { display:inline-flex; width:1rem; height:1rem; margin-right:.32rem; vertical-align:middle; }
+.brand-icon svg { width:100%; height:100%; display:block; }
+.icon-btn { display:inline-flex; align-items:center; justify-content:center; gap:.22rem; }


### PR DESCRIPTION
### Motivation
- Provide fully local, offline branding and platform icons (no CDN or runtime network requests) and apply the DevSkits 3.1 logo to boot and wallpaper as required by branding rules.
- Replace ad-hoc ASCII boot mark with an inline SVG boot logo and add a subtle desktop watermark while keeping the retro monochrome look.
- Ensure the upper-right desktop area only shows the system clock by removing the previous widget rendering there.

### Description
- Added a local branding registry `js/core/branding.js` that embeds inline SVGs for the DevSkits 3.1 logo and platform icons (GitHub, Facebook, Reddit, X/Twitter, GoFundMe, Venmo, Cash App, Chime, PayPal, plus email/phone/person/location/external/copy/browser/notes/document) and an `icon()` helper for rendering them.
- Replaced the boot ASCII block with a `#boot-logo` container and added a `#desktop-brandmark` overlay in `index.html`, and loaded `js/core/branding.js` early in the script load order.
- Updated `js/core/desktop.js` to inject the inline SVG logo into boot and wallpaper layers via `applyBranding()`, removed the desktop widgets rendering path so the top-right remains clock-only, and improved desktop icon behavior to reliably support click/double-click launching while preserving draggable movement and persisting positions to `localStorage`.
- Updated `js/apps/links.js`, `js/apps/donate.js`, and `js/apps/contact.js` to render iconized UI (icon + label/buttons) using the local branding registry only, and adjusted styling in `style.css` for crisp boot SVG display, subtle watermark treatment, icon/button alignment, and a minimal system tray focused on the clock.

### Testing
- Ran JavaScript static checks with `node --check` on new/modified scripts (`js/core/branding.js`, `js/core/desktop.js`, `js/apps/links.js`, `js/apps/donate.js`, `js/apps/contact.js`) and they succeeded.
- Served the site with `python -m http.server --directory /workspace/DevSkits-OS-2.0` and performed a headless visual smoke-check using Playwright that loaded the page and captured a screenshot artifact; the page loaded and the screenshot was produced successfully.
- Verified that drag-and-drop of desktop icons persisted `devskits-icon-positions` to `localStorage` in a Playwright interaction; the persistence check succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b458e3aa40832dbb0e5102176e4cdc)