### PR TITLE
Revamp Start Menu launcher and desktop icon system

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
   <div id="desktop" class="desktop hidden" role="application" aria-label="DevSkits Desktop">
     <div id="desktop-brandmark" class="desktop-brandmark" aria-hidden="true"></div>
     <div class="scanlines"></div>
-    <div id="desktop-icons" class="desktop-icons"></div>
+    <div id="desktop-icons" class="desktop-icons" tabindex="0" aria-label="Desktop icons"></div>
     <div id="window-layer" class="window-layer"></div>
     <div id="selection-box" class="selection-box hidden"></div>
 
@@ -33,24 +33,13 @@
       <button data-action="terminal">Terminal</button>
       <button data-action="settings">Settings</button>
       <button data-action="reboot">Reboot</button>
-        <button data-action="shutdown">Shut Down</button>
+      <button data-action="shutdown">Shut Down</button>
     </div>
 
-    <div id="start-menu" class="start-menu hidden" aria-hidden="true">
-      <div class="start-header">DevSkits Menu</div>
-      <input id="start-search" class="start-search" placeholder="Search apps..." aria-label="Search apps" />
-      <div id="start-recent" class="start-section"></div>
-      <div class="start-section-label">Apps</div>
-      <div id="start-apps" class="start-section"></div>
-      <hr />
-      <div class="start-quick-actions">
-        <button data-action="show-desktop">Show Desktop</button>
-        <button data-action="run">Run...</button>
-        <button data-action="settings">Settings</button>
-        <button data-action="about">About System</button>
-        <button data-action="reboot">Reboot</button>
-        <button data-action="shutdown">Shut Down</button>
-      </div>
+    <div id="start-menu" class="start-menu hidden" aria-hidden="true" role="menu" aria-label="Start Menu">
+      <div class="start-header">DevSkits Launcher</div>
+      <input id="start-search" class="start-search" placeholder="Search launcher..." aria-label="Search apps" />
+      <div id="start-sections" class="start-sections"></div>
     </div>
 
     <div id="notification-area" class="notification-area"></div>
@@ -68,7 +57,7 @@
     </div>
 
     <footer class="taskbar">
-      <button id="start-btn" class="start-btn" aria-expanded="false">DevSkits</button>
+      <button id="start-btn" class="start-btn" aria-expanded="false" aria-controls="start-menu">Start</button>
       <div id="task-buttons" class="task-buttons" aria-label="Open windows"></div>
       <div class="system-tray">
         <time id="clock"></time>
@@ -78,7 +67,7 @@
 
   <template id="desktop-icon-template">
     <button class="desktop-icon" type="button">
-      <span class="icon-glyph">◼</span>
+      <span class="icon-glyph" aria-hidden="true"></span>
       <span class="icon-label"></span>
     </button>
   </template>

--- a/js/core/desktop.js
+++ b/js/core/desktop.js
@@ -1,6 +1,8 @@
 (() => {
   const { state, APPS, ui } = window.DevSkitsState;
   const W = () => window.DevSkitsWorld;
+  const GRID = { x: 96, y: 104, margin: 8 };
+  let selectedIconId = null;
 
   function applyTheme(theme) {
     if (theme === "default") document.body.removeAttribute("data-theme");
@@ -37,20 +39,83 @@
     if (desktopLogo) desktopLogo.innerHTML = logo;
   }
 
+  function launchDesktopEntry(entry) {
+    if (!entry.isShortcut) return window.DevSkitsWindowManager.launchApp(entry.id);
+    if (entry.shortcut.type === "route") return window.DevSkitsWindowManager.launchApp("browser", { route: entry.shortcut.target });
+    return window.DevSkitsWindowManager.launchApp(entry.shortcut.target);
+  }
+
+  function getDesktopEntries() {
+    const appEntries = Object.entries(APPS)
+      .filter(([, app]) => app.desktopVisible)
+      .map(([id, app]) => ({ id, app, isShortcut: false }));
+    const shortcuts = (W()?.getShortcuts?.() || [])
+      .map((s) => ({ id: s.id, app: { title: s.label, iconSvg: s.iconSvg || APPS.browser.iconSvg }, isShortcut: true, shortcut: s }));
+    return [...appEntries, ...shortcuts];
+  }
+
+  function snapToGrid(x, y) {
+    return {
+      x: Math.round((x - GRID.margin) / GRID.x) * GRID.x + GRID.margin,
+      y: Math.round((y - GRID.margin) / GRID.y) * GRID.y + GRID.margin
+    };
+  }
+
+  function clampIconPosition(x, y) {
+    const maxX = Math.max(GRID.margin, ui.iconContainer.clientWidth - 94);
+    const maxY = Math.max(GRID.margin, ui.iconContainer.clientHeight - 96);
+    return {
+      x: Math.min(maxX, Math.max(GRID.margin, x)),
+      y: Math.min(maxY, Math.max(GRID.margin, y))
+    };
+  }
+
+  function saveIconPosition(id, x, y) {
+    state.iconPositions[id] = clampIconPosition(x, y);
+    localStorage.setItem("devskits-icon-positions", JSON.stringify(state.iconPositions));
+  }
+
+  function selectIcon(iconId, shouldFocus = false) {
+    selectedIconId = iconId;
+    ui.iconContainer.querySelectorAll(".desktop-icon").forEach((node) => {
+      const active = node.dataset.app === iconId;
+      node.classList.toggle("selected", active);
+      node.setAttribute("aria-selected", String(active));
+      if (active && shouldFocus) node.focus();
+    });
+  }
+
+  function clearIconSelection() {
+    selectedIconId = null;
+    ui.iconContainer.querySelectorAll(".desktop-icon.selected").forEach((n) => {
+      n.classList.remove("selected");
+      n.setAttribute("aria-selected", "false");
+    });
+  }
+
   function buildDesktopIcons() {
     const tpl = document.querySelector("#desktop-icon-template");
     ui.iconContainer.innerHTML = "";
-    const appEntries = Object.entries(APPS).map(([id, app]) => ({ id, app, isShortcut: false }));
-    const shortcuts = (W()?.getShortcuts?.() || []).map((s) => ({ id: s.id, app: { title: s.label, icon: s.icon || "◫" }, isShortcut: true, shortcut: s }));
-    [...appEntries, ...shortcuts].forEach((entry, index) => {
+    clearIconSelection();
+
+    getDesktopEntries().forEach((entry, index) => {
       const node = tpl.content.firstElementChild.cloneNode(true);
       node.dataset.app = entry.id;
-      node.querySelector(".icon-glyph").textContent = entry.app.icon;
+      node.querySelector(".icon-glyph").innerHTML = entry.app.iconSvg || APPS.about.iconSvg;
       node.querySelector(".icon-label").textContent = entry.app.title;
       node.style.position = "absolute";
-      const pos = state.iconPositions[entry.id] || { x: 8 + (index % 5) * 94, y: 8 + Math.floor(index / 5) * 100 };
-      node.style.left = `${pos.x}px`;
-      node.style.top = `${pos.y}px`;
+      node.setAttribute("role", "option");
+      node.setAttribute("aria-label", entry.app.title);
+      node.setAttribute("aria-selected", "false");
+      node.setAttribute("tabindex", "-1");
+
+      const fallback = snapToGrid(GRID.margin + (index % 7) * GRID.x, GRID.margin + Math.floor(index / 7) * GRID.y);
+      const saved = state.iconPositions[entry.id] || fallback;
+      const safe = clampIconPosition(saved.x, saved.y);
+      node.style.left = `${safe.x}px`;
+      node.style.top = `${safe.y}px`;
+      saveIconPosition(entry.id, safe.x, safe.y);
+
       wireIcon(node, entry);
       ui.iconContainer.appendChild(node);
     });
@@ -58,49 +123,105 @@
 
   function wireIcon(node, entry) {
     let drag = null;
-    let moved = false;
-    let clickTimer = null;
+    let dragged = false;
+    let suppressClick = false;
 
-    function openEntry() {
-      if (!entry.isShortcut) window.DevSkitsWindowManager.openApp(entry.id);
-      else if (entry.shortcut.type === "route") window.DevSkitsWindowManager.openApp("browser", { route: entry.shortcut.target });
-      else window.DevSkitsWindowManager.openApp(entry.shortcut.target);
-    }
+    node.addEventListener("click", () => {
+      if (suppressClick) return;
+      selectIcon(entry.id);
+    });
 
     node.addEventListener("dblclick", (e) => {
       e.preventDefault();
-      clearTimeout(clickTimer);
-      if (!moved) openEntry();
+      if (dragged) return;
+      selectIcon(entry.id);
+      launchDesktopEntry(entry);
     });
 
-    node.addEventListener("click", () => {
-      clearTimeout(clickTimer);
-      if (moved) return;
-      clickTimer = setTimeout(() => openEntry(), 180);
+    node.addEventListener("keydown", (e) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        launchDesktopEntry(entry);
+      }
     });
 
     node.addEventListener("pointerdown", (e) => {
-      moved = false;
-      drag = { dx: e.offsetX, dy: e.offsetY, startX: e.clientX, startY: e.clientY };
+      if (e.button !== 0 && e.pointerType !== "touch") return;
+      const rect = node.getBoundingClientRect();
+      dragged = false;
+      suppressClick = false;
+      selectIcon(entry.id, true);
+      drag = {
+        pointerId: e.pointerId,
+        originX: e.clientX,
+        originY: e.clientY,
+        left: parseInt(node.style.left, 10) || 0,
+        top: parseInt(node.style.top, 10) || 0,
+        offsetX: e.clientX - rect.left,
+        offsetY: e.clientY - rect.top
+      };
       node.setPointerCapture(e.pointerId);
     });
 
     node.addEventListener("pointermove", (e) => {
-      if (!drag) return;
-      const shift = Math.abs(e.clientX - drag.startX) + Math.abs(e.clientY - drag.startY);
-      moved = moved || shift > 4;
-      const x = Math.max(0, Math.min(e.clientX - drag.dx, window.innerWidth - 94));
-      const y = Math.max(0, Math.min(e.clientY - drag.dy, window.innerHeight - 130));
-      node.style.left = `${x}px`;
-      node.style.top = `${y}px`;
+      if (!drag || e.pointerId !== drag.pointerId) return;
+      const shift = Math.hypot(e.clientX - drag.originX, e.clientY - drag.originY);
+      const threshold = e.pointerType === "touch" ? 8 : 4;
+      if (!dragged && shift > threshold) {
+        dragged = true;
+        document.body.classList.add("dragging-icons");
+        node.classList.add("dragging");
+      }
+      if (!dragged) return;
+      const rawX = e.clientX - drag.offsetX;
+      const rawY = e.clientY - drag.offsetY;
+      const safe = clampIconPosition(rawX, rawY);
+      node.style.left = `${safe.x}px`;
+      node.style.top = `${safe.y}px`;
     });
 
-    node.addEventListener("pointerup", () => {
-      if (!drag) return;
-      state.iconPositions[entry.id] = { x: parseInt(node.style.left, 10), y: parseInt(node.style.top, 10) };
-      localStorage.setItem("devskits-icon-positions", JSON.stringify(state.iconPositions));
+    node.addEventListener("pointerup", (e) => {
+      if (!drag || e.pointerId !== drag.pointerId) return;
+      node.releasePointerCapture(e.pointerId);
+      if (dragged) {
+        const snapped = snapToGrid(parseInt(node.style.left, 10), parseInt(node.style.top, 10));
+        const safe = clampIconPosition(snapped.x, snapped.y);
+        node.style.left = `${safe.x}px`;
+        node.style.top = `${safe.y}px`;
+        saveIconPosition(entry.id, safe.x, safe.y);
+        suppressClick = true;
+        setTimeout(() => { suppressClick = false; }, 120);
+      }
+      document.body.classList.remove("dragging-icons");
+      node.classList.remove("dragging");
       drag = null;
-      setTimeout(() => { moved = false; }, 0);
+      dragged = false;
+    });
+  }
+
+  function bindDesktopInteractions() {
+    ui.iconContainer.addEventListener("click", (e) => {
+      if (e.target.closest(".desktop-icon") || e.target.closest(".window")) return;
+      clearIconSelection();
+    });
+
+    ui.iconContainer.addEventListener("keydown", (e) => {
+      const icons = [...ui.iconContainer.querySelectorAll(".desktop-icon")];
+      if (!icons.length) return;
+      const currentIndex = icons.findIndex((icon) => icon.dataset.app === selectedIconId);
+
+      if (e.key === "Enter" && selectedIconId) {
+        e.preventDefault();
+        icons[currentIndex]?.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
+      }
+
+      const keyMap = { ArrowDown: 7, ArrowUp: -7, ArrowRight: 1, ArrowLeft: -1 };
+      if (!(e.key in keyMap)) return;
+      e.preventDefault();
+      const nextIndex = Math.max(0, Math.min(icons.length - 1, (currentIndex === -1 ? 0 : currentIndex) + keyMap[e.key]));
+      const next = icons[nextIndex];
+      if (!next) return;
+      selectIcon(next.dataset.app, true);
     });
   }
 
@@ -120,7 +241,7 @@
       if (action === "refresh") buildDesktopIcons();
       if (action === "new-note") window.dispatchEvent(new CustomEvent("devskits:new-note"));
       if (action === "new-sticky") createSticky();
-      if (action === "terminal" || action === "settings") window.DevSkitsWindowManager.openApp(action);
+      if (action === "terminal" || action === "settings") window.DevSkitsWindowManager.launchApp(action);
       if (action === "reboot") rebootSystem();
       menu.classList.add("hidden");
     });
@@ -186,10 +307,10 @@
     const appAlias = {
       browser: "browser", navigator: "browser", terminal: "terminal", files: "files", notes: "notes", links: "links", settings: "settings", projects: "projects", contact: "contact", donate: "donate", about: "about"
     };
-    if (cmd.startsWith("devskits://")) return window.DevSkitsWindowManager.openApp("browser", { route: cmd });
+    if (cmd.startsWith("devskits://")) return window.DevSkitsWindowManager.launchApp("browser", { route: cmd });
     if (cmd.startsWith("open ")) return runCommand(cmd.replace(/^open\s+/, ""));
     const target = appAlias[cmd];
-    if (target) return window.DevSkitsWindowManager.openApp(target);
+    if (target) return window.DevSkitsWindowManager.launchApp(target);
     notify("Run: command not found", "warn");
   }
 
@@ -266,8 +387,10 @@
     toggleCRT(state.crt);
     applyBranding();
     buildDesktopIcons();
+    bindDesktopInteractions();
     bindDesktopContextMenu();
     bindRunDialog();
+    window.addEventListener("resize", () => buildDesktopIcons());
     W().getSticky().forEach((s) => createSticky(s));
     updateClock();
     setInterval(updateClock, 1000);

--- a/js/core/start-menu.js
+++ b/js/core/start-menu.js
@@ -1,45 +1,89 @@
 (() => {
-  const { APPS, state } = window.DevSkitsState;
+  const { APPS, START_MENU_SECTIONS } = window.DevSkitsState;
 
-  const CATEGORY_ORDER = ["System", "Identity", "Tools", "Projects", "Network", "Support", "Companion", "Creator", "Dev", "Media"];
+  const POWER_ITEMS = {
+    reboot: { id: "reboot", title: "Reboot", iconSvg: APPS.settings.iconSvg },
+    shutdown: { id: "shutdown", title: "Shut Down", iconSvg: APPS.terminal.iconSvg }
+  };
 
-  function groupApps(filter = "") {
-    const q = filter.trim().toLowerCase();
-    const grouped = {};
-    Object.entries(APPS)
-      .filter(([, app]) => `${app.title} ${app.category}`.toLowerCase().includes(q))
-      .forEach(([id, app]) => {
-        const category = app.category || "Other";
-        grouped[category] = grouped[category] || [];
-        grouped[category].push({ id, app });
-      });
-    return grouped;
-  }
+  let focusedIndex = -1;
 
-  function renderStartApps(filter = "") {
-    const wrap = document.querySelector("#start-apps");
-    const grouped = groupApps(filter);
-    const ordered = [...CATEGORY_ORDER.filter((c) => grouped[c]), ...Object.keys(grouped).filter((c) => !CATEGORY_ORDER.includes(c)).sort()];
-    wrap.innerHTML = ordered.map((category) => `
-      <section class="start-category">
-        <div class="start-section-label">${category}</div>
-        ${grouped[category].map(({ id, app }) => `<button data-open="${id}"><span>${app.icon} ${app.title}</span><small>${category}</small></button>`).join("")}
-      </section>`).join("") || '<small>No matching apps.</small>';
-  }
-
-  function renderRecent() {
-    const wrap = document.querySelector("#start-recent");
-    if (!state.recentApps.length) {
-      wrap.innerHTML = '<div class="start-section-label">Recent: none</div>';
-      return;
-    }
-    const recentActivity = (window.DevSkitsWorld?.getRecentActivity?.() || []).slice(0, 3);
-    wrap.innerHTML = `<div class="start-section-label">Recent</div>${state.recentApps.map((id) => `<button data-open="${id}">${APPS[id]?.title || id}</button>`).join("")}<div class="start-section-label">Activity</div>${recentActivity.map((r) => `<small>${r.type}: ${r.detail}</small>`).join("")}`;
+  function menuNodes() {
+    return [...document.querySelectorAll("#start-menu .start-item")];
   }
 
   function hideMenu() {
-    document.querySelector("#start-menu").classList.add("hidden");
-    document.querySelector("#start-btn").setAttribute("aria-expanded", "false");
+    const menu = document.querySelector("#start-menu");
+    const btn = document.querySelector("#start-btn");
+    menu.classList.add("hidden");
+    menu.setAttribute("aria-hidden", "true");
+    btn.classList.remove("active");
+    btn.setAttribute("aria-expanded", "false");
+    focusedIndex = -1;
+  }
+
+  function openMenu() {
+    const menu = document.querySelector("#start-menu");
+    const btn = document.querySelector("#start-btn");
+    renderStartMenu(document.querySelector("#start-search").value || "");
+    menu.classList.remove("hidden");
+    menu.setAttribute("aria-hidden", "false");
+    btn.classList.add("active");
+    btn.setAttribute("aria-expanded", "true");
+    setTimeout(() => document.querySelector("#start-search").focus(), 10);
+  }
+
+  function toggleMenu() {
+    const isHidden = document.querySelector("#start-menu").classList.contains("hidden");
+    if (isHidden) openMenu();
+    else hideMenu();
+  }
+
+  function renderItem(itemId) {
+    if (itemId === "run") return `<button class="start-item" type="button" data-action="run" role="menuitem"><span class="start-item-icon">${APPS.terminal.iconSvg}</span><span class="start-item-text"><strong>Run</strong><small>Open command launcher</small></span></button>`;
+    if (POWER_ITEMS[itemId]) {
+      const p = POWER_ITEMS[itemId];
+      return `<button class="start-item" type="button" data-action="${p.id}" role="menuitem"><span class="start-item-icon">${p.iconSvg}</span><span class="start-item-text"><strong>${p.title}</strong></span></button>`;
+    }
+    const app = APPS[itemId];
+    if (!app) return "";
+    return `<button class="start-item" type="button" data-open="${itemId}" role="menuitem"><span class="start-item-icon">${app.iconSvg}</span><span class="start-item-text"><strong>${app.title}</strong><small>${app.description || app.category}</small></span></button>`;
+  }
+
+  function renderStartMenu(filter = "") {
+    const q = filter.trim().toLowerCase();
+    const sectionsWrap = document.querySelector("#start-sections");
+    sectionsWrap.innerHTML = START_MENU_SECTIONS.map((section) => {
+      const items = section.items
+        .filter((id) => {
+          if (!q) return true;
+          if (POWER_ITEMS[id]) return POWER_ITEMS[id].title.toLowerCase().includes(q);
+          const app = APPS[id];
+          return app && `${app.title} ${app.category}`.toLowerCase().includes(q);
+        })
+        .map(renderItem)
+        .join("");
+      if (!items) return "";
+      return `<section class="start-group"><h3 class="start-section-label">${section.label}</h3><div class="start-group-items">${items}</div></section>`;
+    }).join("") || '<div class="start-empty">No matching apps.</div>';
+
+    focusedIndex = -1;
+  }
+
+  function launchFromMenu(target, action) {
+    if (target) window.DevSkitsWindowManager.launchApp(target);
+    if (action === "run") window.DevSkitsDesktop.openRunDialog();
+    if (action === "reboot") window.DevSkitsDesktop.rebootSystem();
+    if (action === "shutdown") location.reload();
+    hideMenu();
+  }
+
+  function moveFocus(step) {
+    const items = menuNodes();
+    if (!items.length) return;
+    focusedIndex = Math.max(0, Math.min(items.length - 1, focusedIndex + step));
+    items.forEach((n, idx) => n.classList.toggle("focused", idx === focusedIndex));
+    items[focusedIndex].focus();
   }
 
   function bindStartMenu() {
@@ -47,35 +91,48 @@
     const btn = document.querySelector("#start-btn");
     const search = document.querySelector("#start-search");
 
-    btn.addEventListener("click", () => {
-      const hidden = menu.classList.toggle("hidden");
-      btn.setAttribute("aria-expanded", String(!hidden));
-      renderRecent();
-      renderStartApps(search.value);
-      if (!hidden) setTimeout(() => search.focus(), 10);
-    });
+    btn.addEventListener("click", toggleMenu);
 
     menu.addEventListener("click", (e) => {
       const app = e.target.closest("button[data-open]")?.dataset.open;
       const action = e.target.closest("button[data-action]")?.dataset.action;
-      if (app) window.DevSkitsWindowManager.openApp(app);
-      if (action === "show-desktop") window.DevSkitsWindowManager.showDesktop();
-      if (action === "run") window.DevSkitsDesktop.openRunDialog();
-      if (action === "settings") window.DevSkitsWindowManager.openApp("settings");
-      if (action === "about") window.DevSkitsWindowManager.openApp("about");
-      if (action === "reboot") window.DevSkitsDesktop.rebootSystem();
-      if (action === "shutdown") location.reload();
-      if (app || action) hideMenu();
+      if (app || action) launchFromMenu(app, action);
     });
 
-    search.addEventListener("input", (e) => renderStartApps(e.target.value));
+    search.addEventListener("input", (e) => renderStartMenu(e.target.value));
+
+    menu.addEventListener("keydown", (e) => {
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        moveFocus(1);
+      }
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        moveFocus(-1);
+      }
+      if (e.key === "Enter") {
+        const active = document.activeElement.closest(".start-item");
+        if (active) {
+          e.preventDefault();
+          launchFromMenu(active.dataset.open, active.dataset.action);
+        }
+      }
+      if (e.key === "Escape") {
+        e.preventDefault();
+        hideMenu();
+      }
+    });
+
     document.addEventListener("click", (e) => {
       if (!menu.contains(e.target) && e.target !== btn) hideMenu();
     });
+
     document.addEventListener("keydown", (e) => {
       if (e.key === "Escape") hideMenu();
     });
+
+    window.addEventListener("devskits:app-launched", hideMenu);
   }
 
-  window.DevSkitsStartMenu = { bindStartMenu, hideMenu, renderStartApps, renderRecent };
+  window.DevSkitsStartMenu = { bindStartMenu, hideMenu, renderStartMenu };
 })();

--- a/js/core/state.js
+++ b/js/core/state.js
@@ -1,39 +1,70 @@
 (() => {
+  function icon(monogram) {
+    return `<svg viewBox="0 0 16 16" aria-hidden="true" focusable="false"><rect x="1" y="1" width="14" height="14" fill="none" stroke="currentColor"/><text x="8" y="11" text-anchor="middle" font-size="6" font-family="monospace" fill="currentColor">${monogram}</text></svg>`;
+  }
+
+  function defineApp(id, config) {
+    return {
+      id,
+      description: "",
+      desktopVisible: true,
+      startMenuVisible: true,
+      multiInstance: false,
+      category: "System",
+      ...config,
+      launch(options = {}) {
+        return window.DevSkitsWindowManager.openApp(id, options);
+      }
+    };
+  }
+
   const APPS = {
-    terminal: { title: "Terminal", icon: ">_", category: "System" },
-    browser: { title: "Navigator", icon: "WWW", category: "Network" },
-    inbox: { title: "Inbox", icon: "✉", category: "Network" },
-    updater: { title: "System Update", icon: "UPD", category: "System" },
-    processmon: { title: "Process Monitor", icon: "CPU", category: "System" },
-    activity: { title: "Activity", icon: "ACT", category: "System" },
-    syslogs: { title: "System Logs", icon: "LOG", category: "System" },
-    reminders: { title: "Reminders", icon: "REM", category: "Tools" },
-    profile: { title: "System Identity", icon: "ID", category: "System" },
-    presence: { title: "Network Status", icon: "NET", category: "Network" },
-    buildlog: { title: "Build Log", icon: "LOG", category: "System" },
-    mediadeck: { title: "Media Deck", icon: "▶", category: "Media" },
-    packages: { title: "Install Center", icon: "PKG", category: "System" },
-    achievements: { title: "Discoveries", icon: "★", category: "System" },
-    recycle: { title: "Recycle Bin", icon: "BIN", category: "System" },
-    files: { title: "Files", icon: "▣", category: "System" },
-    settings: { title: "Settings", icon: "⚙", category: "System" },
-    calculator: { title: "Calculator", icon: "⊞", category: "Tools" },
-    calendar: { title: "Calendar", icon: "▦", category: "Tools" },
-    clock: { title: "Clock", icon: "◷", category: "Tools" },
-    quoteforge: { title: "Quote Forge", icon: "❞", category: "Creator" },
-    asciimaker: { title: "ASCII Maker", icon: "#", category: "Creator" },
-    draftpad: { title: "Post Draft Pad", icon: "✎", category: "Creator" },
-    networkmap: { title: "Network Map", icon: "⌗", category: "Network" },
-    lokigame: { title: "Loki Mini Game", icon: "🐾", category: "Companion" },
-    search: { title: "Search Everywhere", icon: "⌕", category: "System" },
-    projects: { title: "Projects", icon: "⌘", category: "Dev" },
-    notes: { title: "Notes", icon: "TXT", category: "Dev" },
-    links: { title: "Links", icon: "↗", category: "Network" },
-    contact: { title: "Contact", icon: "☎", category: "Network" },
-    donate: { title: "Donate", icon: "$", category: "Support" },
-    loki: { title: "Loki", icon: "DOG", category: "Companion" },
-    about: { title: "About", icon: "i", category: "System" }
+    terminal: defineApp("terminal", { title: "Terminal", icon: ">_", iconSvg: icon("T"), category: "System", desktopVisible: true }),
+    files: defineApp("files", { title: "Files", icon: "▣", iconSvg: icon("F"), category: "System" }),
+    settings: defineApp("settings", { title: "Settings", icon: "⚙", iconSvg: icon("S"), category: "System" }),
+    activity: defineApp("activity", { title: "Activity Log", icon: "ACT", iconSvg: icon("A"), category: "System", desktopVisible: false }),
+    recycle: defineApp("recycle", { title: "Recycle Bin", icon: "BIN", iconSvg: icon("R"), category: "System" }),
+
+    about: defineApp("about", { title: "About", icon: "i", iconSvg: icon("i"), category: "Identity" }),
+    contact: defineApp("contact", { title: "Contact", icon: "☎", iconSvg: icon("C"), category: "Identity" }),
+    links: defineApp("links", { title: "Links", icon: "↗", iconSvg: icon("L"), category: "Identity" }),
+    donate: defineApp("donate", { title: "Donate", icon: "$", iconSvg: icon("$"), category: "Identity" }),
+    loki: defineApp("loki", { title: "Loki", icon: "DOG", iconSvg: icon("K"), category: "Identity" }),
+
+    projects: defineApp("projects", { title: "Projects", icon: "⌘", iconSvg: icon("P"), category: "Projects" }),
+    notes: defineApp("notes", { title: "Notes", icon: "TXT", iconSvg: icon("N"), category: "Projects" }),
+    browser: defineApp("browser", { title: "Navigator", icon: "WWW", iconSvg: icon("W"), category: "Projects" }),
+    reminders: defineApp("reminders", { title: "Planner", icon: "REM", iconSvg: icon("PL"), category: "Projects" }),
+    calculator: defineApp("calculator", { title: "Calculator", icon: "⊞", iconSvg: icon("+"), category: "Projects" }),
+
+    run: defineApp("run", { title: "Run", icon: ">", iconSvg: icon(">"), category: "System", desktopVisible: false, startMenuVisible: false }),
+
+    inbox: defineApp("inbox", { title: "Inbox", icon: "✉", iconSvg: icon("I"), category: "Network", startMenuVisible: false, desktopVisible: false }),
+    updater: defineApp("updater", { title: "System Update", icon: "UPD", iconSvg: icon("U"), category: "System", startMenuVisible: false, desktopVisible: false }),
+    processmon: defineApp("processmon", { title: "Process Monitor", icon: "CPU", iconSvg: icon("PM"), category: "System", startMenuVisible: false, desktopVisible: false }),
+    syslogs: defineApp("syslogs", { title: "System Logs", icon: "LOG", iconSvg: icon("LG"), category: "System", startMenuVisible: false, desktopVisible: false }),
+    profile: defineApp("profile", { title: "System Identity", icon: "ID", iconSvg: icon("ID"), category: "System", startMenuVisible: false, desktopVisible: false }),
+    presence: defineApp("presence", { title: "Network Status", icon: "NET", iconSvg: icon("NE"), category: "Network", startMenuVisible: false, desktopVisible: false }),
+    buildlog: defineApp("buildlog", { title: "Build Log", icon: "LOG", iconSvg: icon("BL"), category: "System", startMenuVisible: false, desktopVisible: false }),
+    mediadeck: defineApp("mediadeck", { title: "Media Deck", icon: "▶", iconSvg: icon("M"), category: "Media", startMenuVisible: false, desktopVisible: false }),
+    packages: defineApp("packages", { title: "Install Center", icon: "PKG", iconSvg: icon("PK"), category: "System", startMenuVisible: false, desktopVisible: false }),
+    achievements: defineApp("achievements", { title: "Discoveries", icon: "★", iconSvg: icon("*"), category: "System", startMenuVisible: false, desktopVisible: false }),
+    calendar: defineApp("calendar", { title: "Calendar", icon: "▦", iconSvg: icon("CA"), category: "Tools", startMenuVisible: false, desktopVisible: false }),
+    clock: defineApp("clock", { title: "Clock", icon: "◷", iconSvg: icon("CL"), category: "Tools", startMenuVisible: false, desktopVisible: false }),
+    quoteforge: defineApp("quoteforge", { title: "Quote Forge", icon: "❞", iconSvg: icon("Q"), category: "Creator", startMenuVisible: false, desktopVisible: false }),
+    asciimaker: defineApp("asciimaker", { title: "ASCII Maker", icon: "#", iconSvg: icon("#"), category: "Creator", startMenuVisible: false, desktopVisible: false }),
+    draftpad: defineApp("draftpad", { title: "Post Draft Pad", icon: "✎", iconSvg: icon("DP"), category: "Creator", startMenuVisible: false, desktopVisible: false }),
+    networkmap: defineApp("networkmap", { title: "Network Map", icon: "⌗", iconSvg: icon("NM"), category: "Network", startMenuVisible: false, desktopVisible: false }),
+    lokigame: defineApp("lokigame", { title: "Loki Mini Game", icon: "🐾", iconSvg: icon("LG"), category: "Companion", startMenuVisible: false, desktopVisible: false }),
+    search: defineApp("search", { title: "Search Everywhere", icon: "⌕", iconSvg: icon("?"), category: "System", startMenuVisible: false, desktopVisible: false })
   };
+
+  const START_MENU_SECTIONS = [
+    { id: "system", label: "SYSTEM", items: ["terminal", "files", "settings", "run", "activity", "recycle"] },
+    { id: "identity", label: "IDENTITY", items: ["about", "contact", "links", "donate", "loki"] },
+    { id: "projects", label: "PROJECTS", items: ["projects", "notes", "browser", "reminders", "calculator"] },
+    { id: "power", label: "POWER", items: ["reboot", "shutdown"] }
+  ];
 
   const state = {
     windows: new Map(),
@@ -58,5 +89,5 @@
     localStorage.setItem(key, JSON.stringify(value));
   }
 
-  window.DevSkitsState = { APPS, state, ui, saveState };
+  window.DevSkitsState = { APPS, START_MENU_SECTIONS, state, ui, saveState };
 })();

--- a/js/core/window-manager.js
+++ b/js/core/window-manager.js
@@ -3,9 +3,9 @@
 
   function persistSession() {
     const session = [];
-    state.windows.forEach((rec, appId) => {
+    state.windows.forEach((rec) => {
       session.push({
-        appId,
+        appId: rec.appId,
         minimized: rec.minimized,
         maximized: rec.maximized,
         style: {
@@ -27,6 +27,13 @@
     const top = Math.min(maxTop, Math.max(0, parseInt(el.style.top || rect.top, 10)));
     el.style.left = `${left}px`;
     el.style.top = `${top}px`;
+  }
+
+
+  function getWindowKey(appId, options = {}) {
+    const meta = APPS[appId] || {};
+    if (!meta.multiInstance) return appId;
+    return `${appId}:${Date.now()}:${Math.random().toString(16).slice(2, 7)}`;
   }
 
   function focusWindow(appId) {
@@ -180,37 +187,39 @@
     enableResize(win, appId);
   }
 
-  function openApp(appId, options = {}) {
+  function launchApp(appId, options = {}) {
     const render = window.DevSkitsAppRegistry?.[appId];
     if (!APPS[appId] || !render) return;
-    if (state.windows.has(appId)) {
-      restoreWindow(appId);
-      focusWindow(appId);
+    const windowKey = getWindowKey(appId, options);
+    if (!APPS[appId].multiInstance && state.windows.has(windowKey)) {
+      restoreWindow(windowKey);
+      focusWindow(windowKey);
       return;
     }
 
     const win = document.querySelector("#window-template").content.firstElementChild.cloneNode(true);
     const meta = APPS[appId];
-    win.dataset.app = appId;
+    win.dataset.app = windowKey;
     win.querySelector(".window-title").textContent = `${meta.title} - DevSkits 3.1`;
     win.style.left = `${Math.min(80 + state.windows.size * 22, window.innerWidth - 360)}px`;
     win.style.top = `${Math.min(70 + state.windows.size * 18, window.innerHeight - 260)}px`;
     win.style.zIndex = ++state.z;
 
-    wireWindow(win, appId);
+    wireWindow(win, windowKey);
     ui.windowLayer.appendChild(win);
 
-    const record = { el: win, minimized: false, maximized: false };
-    state.windows.set(appId, record);
-    createTaskButton(appId, meta.title);
+    const record = { el: win, minimized: false, maximized: false, appId };
+    state.windows.set(windowKey, record);
+    createTaskButton(windowKey, meta.title);
     render(win.querySelector(".window-content"), options);
-    focusWindow(appId);
+    focusWindow(windowKey);
 
     state.recentApps = [appId, ...state.recentApps.filter((id) => id !== appId)].slice(0, 5);
     window.DevSkitsWorld?.trackActivity?.("app", `opened ${appId}`);
     window.DevSkitsWorld?.registerAppOpen?.(appId);
     localStorage.setItem("devskits-recent-apps", JSON.stringify(state.recentApps));
     persistSession();
+    window.dispatchEvent(new CustomEvent("devskits:app-launched", { detail: { appId } }));
   }
 
   function restoreSession() {
@@ -221,7 +230,7 @@
       items = [];
     }
     items.forEach((item) => {
-      openApp(item.appId);
+      launchApp(item.appId);
       const rec = state.windows.get(item.appId);
       if (!rec) return;
       Object.assign(rec.el.style, item.style || {});
@@ -229,7 +238,7 @@
       if (item.maximized) toggleMaximize(item.appId);
       if (item.minimized) minimizeWindow(item.appId);
     });
-    if (!items.length) openApp("about");
+    if (!items.length) launchApp("about");
   }
 
   function showDesktop() {
@@ -239,12 +248,13 @@
   window.addEventListener("resize", () => state.windows.forEach((rec) => clampToViewport(rec.el)));
 
   window.DevSkitsWindowManager = {
-    openApp,
+    launchApp,
     closeWindow,
     restoreSession,
     focusWindow,
     showDesktop,
     persistSession,
-    snapWindow
+    snapWindow,
+    openApp: launchApp
   };
 })();

--- a/style.css
+++ b/style.css
@@ -142,3 +142,71 @@ fieldset label { display:block; margin:.15rem 0; }
 body.reduce-motion .window { transition:none; }
 body[data-icon-density="compact"] .desktop-icon { width:76px; min-height:76px; }
 body[data-icon-density="compact"] .icon-label { font-size:.65rem; }
+
+.desktop-icons { user-select:none; touch-action:none; }
+.dragging-icons, .dragging-icons * { user-select:none !important; }
+.desktop-icon {
+  width:92px;
+  min-height:94px;
+  padding:.3rem .2rem;
+  gap:.34rem;
+  border:1px solid transparent;
+}
+.desktop-icon .icon-glyph svg { width:100%; height:100%; }
+.icon-glyph { width:36px; height:30px; }
+.icon-label {
+  max-width:90px;
+  white-space:nowrap;
+  overflow:hidden;
+  text-overflow:ellipsis;
+  line-height:1.2;
+}
+.desktop-icon:hover { background:rgba(255,255,255,.45); }
+.desktop-icon:active { border-color:var(--border-dark); background:rgba(0,0,0,.08); }
+.desktop-icon.selected {
+  border-color:var(--border-dark);
+  background:rgba(255,255,255,.66);
+  box-shadow:inset 0 0 0 1px #fff;
+}
+.desktop-icon.dragging { opacity:.62; z-index:2100; }
+
+.start-btn.active,
+.start-btn[aria-expanded="true"] { border-style:inset; background:#cdcdcd; }
+.start-menu {
+  width:min(360px,95vw);
+  max-height:min(70vh,520px);
+  overflow:auto;
+  border:2px solid var(--border-dark);
+  box-shadow:0 0 0 1px #fff inset, 6px 6px 0 rgba(0,0,0,.35);
+  padding:.45rem;
+}
+.start-header { font-size:.78rem; letter-spacing:.04em; }
+.start-sections { display:grid; gap:.45rem; }
+.start-group { border-top:1px solid #a8a8a8; padding-top:.35rem; }
+.start-group:first-child { border-top:none; padding-top:0; }
+.start-section-label { font-size:.68rem; letter-spacing:.08em; opacity:.9; margin-bottom:.2rem; }
+.start-group-items { display:grid; gap:.18rem; }
+.start-item {
+  width:100%;
+  display:flex;
+  align-items:center;
+  gap:.45rem;
+  border:1px solid transparent;
+  background:transparent;
+  text-align:left;
+  padding:.24rem;
+}
+.start-item-icon { width:20px; height:20px; display:inline-flex; }
+.start-item-icon svg { width:100%; height:100%; }
+.start-item-text { display:grid; }
+.start-item-text small { opacity:.74; font-size:.63rem; }
+.start-item:hover,
+.start-item.focused,
+.start-item:focus-visible { border-color:var(--border-dark); background:#e2e2e2; outline:none; }
+.start-item:active { border-style:inset; }
+.start-empty { font-size:.72rem; opacity:.7; padding:.35rem .2rem; }
+
+@media (max-width: 780px) {
+  .desktop-icons { inset:.35rem .35rem 3rem .35rem; }
+  .start-menu { left:.15rem; bottom:2.45rem; width:calc(100vw - .3rem); }
+}


### PR DESCRIPTION
### Motivation
- Make the Start/Menu experience feel like a focused OS launcher with clear grouping, keyboard affordances, and polished visual states.  
- Turn desktop icons into first-class, movable shortcuts that behave like a real retro desktop (select, drag, double-click to open).  
- Consolidate app metadata and launch behavior into a single source-of-truth so desktop and menu both invoke the same app logic.  

### Description
- Centralized app metadata into a richer registry in `js/core/state.js` (inline `iconSvg`, `desktopVisible`, `startMenuVisible`, `multiInstance`, `launch()`), and added `START_MENU_SECTIONS` to define `SYSTEM / IDENTITY / PROJECTS / POWER`.  
- Rebuilt the Start Menu in `js/core/start-menu.js` to render grouped sections from the registry, add ARIA/role wiring, close-on-outside-click/Escape/launch, keyboard navigation (Arrow keys, Enter, Escape), and visual focus/hover states.  
- Implemented the desktop icon system in `js/core/desktop.js` with single-click select, double-click open, Enter-to-open, keyboard traversal, pointer/touch drag support, drag thresholding, snap-to-grid, viewport clamping, and persistence to `localStorage` (`devskits-icon-positions`).  
- Unified app launching in `js/core/window-manager.js` via `launchApp()` (preserves `openApp` alias), added multi-instance keys and `devskits:app-launched` event so Start Menu auto-closes on launch, and ensured opened windows are focused instead of duplicated.  
- Small markup and styling updates in `index.html` and `style.css` to add the Start button toggle, menu structure, icon template for inline SVG, and retro visual improvements (selected, dragging, pressed states, section dividers).  
- Files changed include: `index.html`, `style.css`, `js/core/state.js`, `js/core/start-menu.js`, `js/core/desktop.js`, and `js/core/window-manager.js`.

### Testing
- Parsed and executed updated modules with Node to check for syntax errors using `node -e` and the load-run succeeded (no exceptions). — passed.  
- Checked repository whitespace/diff issues with `git diff --check` — passed.  
- Served the site with `python -m http.server` and performed a smoke-test that loads the page, skips the boot screen, opens Start Menu and captures a screenshot via an automated Playwright flow — smoke test completed and screenshot produced. — passed.  
- Changes were committed in a single commit describing the launcher and desktop icon updates. — passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b45e6e69a4832d88ba4c4c2141a214)