### PR TITLE
Open Contact window by default on fresh desktop startup

### DIFF
--- a/js/core/window-manager.js
+++ b/js/core/window-manager.js
@@ -238,7 +238,10 @@
       if (item.maximized) toggleMaximize(item.appId);
       if (item.minimized) minimizeWindow(item.appId);
     });
-    if (!items.length) launchApp("about");
+    if (!items.length) {
+      launchApp("about");
+      launchApp("contact");
+    }
   }
 
   function showDesktop() {


### PR DESCRIPTION
### Motivation
- Ensure the Contact app is visible on a fresh desktop start when there is no saved window session so users immediately see contact information alongside the About window.

### Description
- Update `restoreSession` in `js/core/window-manager.js` to launch both the `about` and `contact` apps when there are no saved session items.

### Testing
- Ran `node --check js/core/window-manager.js` which completed with no syntax errors.
- Served the app with `python3 -m http.server 4173` and executed a Playwright script against `http://127.0.0.1:4173/index.html` which captured a startup screenshot showing the Contact window open (artifact generated successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4714713d0832d83c01d957fd7b08f)