### PR TITLE
Remove requested apps from Start menu

### DIFF
--- a/js/core/state.js
+++ b/js/core/state.js
@@ -60,9 +60,9 @@
   };
 
   const START_MENU_SECTIONS = [
-    { id: "system", label: "SYSTEM", items: ["terminal", "files", "settings", "run", "activity", "recycle"] },
-    { id: "identity", label: "IDENTITY", items: ["about", "contact", "links", "donate", "loki"] },
-    { id: "projects", label: "PROJECTS", items: ["projects", "notes", "browser", "reminders", "calculator"] },
+    { id: "system", label: "SYSTEM", items: ["terminal", "settings", "run"] },
+    { id: "identity", label: "IDENTITY", items: ["about", "contact", "links", "donate"] },
+    { id: "projects", label: "PROJECTS", items: ["notes"] },
     { id: "power", label: "POWER", items: ["reboot", "shutdown"] }
   ];
 


### PR DESCRIPTION
### Motivation
- Remove several apps from the Start menu sections to match a requested configuration change (Projects, Navigator, Planner, Calculator, Activity Log, Files, Recycle Bin, Loki). 

### Description
- Updated `START_MENU_SECTIONS` in `js/core/state.js` so the System, Identity and Projects groups no longer include the removed entries and now read `[{ id: "system", items: ["terminal","settings","run"] }, { id: "identity", items: ["about","contact","links","donate"] }, { id: "projects", items: ["notes"] }]`.

### Testing
- Served the app locally and ran a Playwright script that clicks `#start-btn` and captures a screenshot, confirming the Start menu no longer lists the removed apps (visual verification succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b473e38f34832db5f9bf9545f0f024)