### PR TITLE
Remove Cash App/PayPal from Donate app and update Start Menu sections

### DIFF
--- a/js/apps/donate.js
+++ b/js/apps/donate.js
@@ -5,9 +5,7 @@
     const items = [
       ["GoFundMe", "https://gofund.me/6bbc0274e", "Community support campaign", "gofundme"],
       ["Venmo", "https://venmo.com/u/DevSkits", "Fast direct support", "venmo"],
-      ["Cash App", "https://cash.app", "Simple peer-to-peer support", "cashapp"],
-      ["Chime", "https://chime.com", "Quick utility donations", "chime"],
-      ["PayPal", "https://paypal.com", "Card and account support", "paypal"]
+      ["Chime", "https://chime.com", "Quick utility donations", "chime"]
     ];
     container.innerHTML = `<h3>${icon("document", "Support DevSkits")}</h3><div class="app-grid">${items.map(([name, url, description, iconName]) => `<article class="project-card"><strong>${icon(iconName, name)}</strong><p>${description}</p><div class="badges"><button class="link-btn icon-btn" data-url="${url}">${icon("external", "Open")}</button></div></article>`).join("")}</div>`;
     container.querySelectorAll(".link-btn").forEach((btn) => btn.addEventListener("click", () => window.open(btn.dataset.url, "_blank", "noopener")));

--- a/js/core/state.js
+++ b/js/core/state.js
@@ -60,8 +60,8 @@
   };
 
   const START_MENU_SECTIONS = [
-    { id: "system", label: "SYSTEM", items: ["terminal", "settings", "run"] },
-    { id: "identity", label: "IDENTITY", items: ["about", "contact", "links", "donate"] },
+    { id: "identity", label: "IDENTITY", items: ["about", "contact", "donate"] },
+    { id: "system", label: "SYSTEM", items: ["terminal", "settings"] },
     { id: "projects", label: "PROJECTS", items: ["notes"] },
     { id: "power", label: "POWER", items: ["reboot", "shutdown"] }
   ];


### PR DESCRIPTION
### Motivation
- Simplify the Donate app listing by removing deprecated or unwanted payment links and keep presented options focused.
- Reorganize the Start Menu sections to reflect a new ordering and remove obsolete entries from the menu.

### Description
- Updated `js/apps/donate.js` to remove the `Cash App` and `PayPal` entries from the `items` array, leaving `GoFundMe`, `Venmo`, and `Chime` as the available options.
- Adjusted `START_MENU_SECTIONS` in `js/core/state.js` to remove the `links` item, remove `run` from the `system` items, and change the section ordering so `identity` appears before `system`.
- Preserved existing app registration and click handling logic for the Donate app so buttons still open external URLs with `window.open`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b475b6ada0832d81cbf7ff87ed662e)