### PR TITLE
Expand Start menu with fully clickable app entries

### DIFF
--- a/js/core/state.js
+++ b/js/core/state.js
@@ -60,10 +60,12 @@
   };
 
   const START_MENU_SECTIONS = [
-    { id: "identity", label: "IDENTITY", items: ["about", "contact", "donate"] },
-    { id: "system", label: "SYSTEM", items: ["terminal", "settings"] },
-    { id: "projects", label: "PROJECTS", items: ["notes"] },
-    { id: "power", label: "POWER", items: ["reboot", "shutdown"] }
+    { id: "identity", label: "IDENTITY", items: ["about", "contact", "links", "donate", "loki"] },
+    { id: "workspace", label: "WORKSPACE", items: ["files", "notes", "projects", "browser", "search", "reminders", "draftpad"] },
+    { id: "tools", label: "TOOLS", items: ["settings", "terminal", "calculator", "calendar", "clock", "asciimaker", "quoteforge"] },
+    { id: "system", label: "SYSTEM", items: ["activity", "processmon", "profile", "presence", "syslogs", "updater", "recycle"] },
+    { id: "extras", label: "EXTRAS", items: ["networkmap", "lokigame", "inbox", "mediadeck", "buildlog", "packages", "achievements"] },
+    { id: "power", label: "POWER", items: ["run", "reboot", "shutdown"] }
   ];
 
   const state = {


### PR DESCRIPTION
### Motivation
- Make the Start menu expose a broader, usable set of apps so each item shows its icon and can be launched from the Start UI.

### Description
- Expanded `START_MENU_SECTIONS` in `js/core/state.js` to add Identity, Workspace, Tools, System, Extras, and Power groups with many more app IDs so items render in the Start menu.
- Included `run` in the Power section so the Run launcher can be opened directly from Start.
- The change reuses each app's existing `iconSvg` metadata so Start menu items are icon-backed and handled by the existing click/keyboard launch logic in `js/core/start-menu.js` and `js/core/desktop.js`.

### Testing
- Ran syntax checks: `node --check js/core/state.js`, `node --check js/core/start-menu.js`, and `node --check js/core/desktop.js` and they passed.
- Ran a Node script to verify all start menu app IDs map to registered renderers and it reported no missing handlers.
- Booted the app in a headless browser and captured a screenshot of the updated Start menu to validate visual/layout and interactivity (screenshot artifact produced successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b477d1571c832da359fbf431735c52)