### PR TITLE
Embed SVG logo as desktop wallpaper (base64 inline)

### DIFF
--- a/js/core/desktop.js
+++ b/js/core/desktop.js
@@ -47,6 +47,11 @@
     const desktopLogo = document.querySelector("#desktop-brandmark");
     if (bootLogo) bootLogo.innerHTML = logo;
     if (desktopLogo) desktopLogo.innerHTML = logo;
+
+    if (ui.desktop && logo) {
+      const encodedLogo = window.btoa(unescape(encodeURIComponent(logo)));
+      ui.desktop.style.setProperty("--desktop-logo", `url("data:image/svg+xml;base64,${encodedLogo}")`);
+    }
   }
 
   function launchDesktopEntry(entry) {

--- a/style.css
+++ b/style.css
@@ -83,12 +83,16 @@ fieldset,
 .desktop {
   position: fixed;
   inset: 0;
-  background: var(--desktop-bg);
+  background-color: var(--desktop-bg);
+  background-image: var(--desktop-logo, none);
+  background-repeat: no-repeat;
+  background-position: center 42%;
+  background-size: min(980px, 86vw) auto;
 }
-.desktop[data-wallpaper="grid"] { background-image: linear-gradient(rgba(255,255,255,.12) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,.12) 1px, transparent 1px); background-size: 16px 16px; }
-.desktop[data-wallpaper="noise"] { background-image: repeating-radial-gradient(rgba(255,255,255,.16) 0 1px, transparent 1px 2px); background-size: 3px 3px; }
-.desktop[data-wallpaper="fade"] { background: linear-gradient(180deg, #10a4a4, var(--desktop-bg)); }
-.desktop-brandmark { position: absolute; inset: 6% 8% auto 8%; display: grid; place-items: center; opacity: .12; pointer-events: none; z-index: 0; }
+.desktop[data-wallpaper="grid"] { background-image: linear-gradient(rgba(255,255,255,.12) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,.12) 1px, transparent 1px), var(--desktop-logo, none); background-size: 16px 16px, 16px 16px, min(980px, 86vw) auto; }
+.desktop[data-wallpaper="noise"] { background-image: repeating-radial-gradient(rgba(255,255,255,.16) 0 1px, transparent 1px 2px), var(--desktop-logo, none); background-size: 3px 3px, min(980px, 86vw) auto; }
+.desktop[data-wallpaper="fade"] { background-image: var(--desktop-logo, none), linear-gradient(180deg, #10a4a4, var(--desktop-bg)); background-size: min(980px, 86vw) auto, cover; }
+.desktop-brandmark { position: absolute; inset: 6% 8% auto 8%; display: none; place-items: center; opacity: .12; pointer-events: none; z-index: 0; }
 .desktop-brandmark svg { width: min(920px, 88vw); }
 .scanlines { position: absolute; inset: 0; pointer-events: none; z-index: 1; background: repeating-linear-gradient(to bottom, rgba(255,255,255,.03) 0 1px, rgba(0,0,0,.02) 2px 3px); }
 


### PR DESCRIPTION
### Motivation
- Make the brand logo appear as the desktop background without relying on external image files.  
- Preserve existing wallpaper modes (`default`, `grid`, `noise`, `fade`) while ensuring the logo remains visible in each mode.  
- Remove the separate overlay element in favor of a single background layer to simplify rendering and avoid duplicated visuals.  

### Description
- Added a CSS variable `--desktop-logo` and updated `.desktop` styles to use it as a centered, no-repeat background with a scalable `background-size`.  
- Updated `data-wallpaper` rules (`grid`, `noise`, `fade`) to composite their patterns with `var(--desktop-logo, none)` so the logo remains visible across modes.  
- Hid the legacy `.desktop-brandmark` overlay by changing it from visible grid to `display: none` since the logo is now part of the wallpaper.  
- In `applyBranding()` (`js/core/desktop.js`) the in-app SVG is UTF-8 encoded, base64-wrapped (`data:image/svg+xml;base64,...`) and injected at runtime into `--desktop-logo` on the `ui.desktop` element.  

### Testing
- Attempted a Playwright load earlier which failed with `ERR_EMPTY_RESPONSE` because the temporary HTTP server was not running.  
- Launched a local HTTP server with `python -m http.server 4173 --directory /workspace/DevSkits-OS-2.0` and retried the automated page load.  
- Ran a Playwright script to open `http://127.0.0.1:4173/index.html` and capture a screenshot, which succeeded and produced `artifacts/desktop-logo-wallpaper.png` showing the embedded logo as the desktop background.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b483652ac8832d919c060a1cdc8953)