### PR TITLE
Open social links within movable/resizable desktop browser windows

### DIFF
--- a/js/apps/contact.js
+++ b/js/apps/contact.js
@@ -4,7 +4,7 @@
   function toLink(value, type) {
     if (type === "email") return `<a href="mailto:${value}">${value}</a>`;
     if (type === "phone") return `<a href="tel:${value}">${value}</a>`;
-    if (type === "url") return `<a href="${value}" target="_blank" rel="noopener">${value}</a>`;
+    if (type === "url") return `<button type="button" class="link-btn contact-url" data-url="${value}">${value}</button>`;
     return value;
   }
 
@@ -15,6 +15,10 @@
     container.querySelectorAll(".copy-btn").forEach((btn) => btn.addEventListener("click", async () => {
       await navigator.clipboard.writeText(btn.dataset.copy).catch(() => {});
       window.DevSkitsDesktop.notify("Copied", "ok");
+    }));
+
+    container.querySelectorAll(".contact-url").forEach((btn) => btn.addEventListener("click", () => {
+      window.DevSkitsWindowManager.openApp("browser", { route: btn.dataset.url });
     }));
 
     container.querySelector("#vcard-download").addEventListener("click", () => {

--- a/js/apps/links.js
+++ b/js/apps/links.js
@@ -5,11 +5,7 @@
     const groups = window.DevSkitsSystemData.links;
     container.innerHTML = Object.entries(groups).map(([group, rows]) => `<h4>${group.toUpperCase()}</h4><div class="app-grid">${rows.map((row) => `<button class="link-btn icon-btn" data-url="${row.url}">${icon(row.icon, row.label)} ${row.label} ${icon("external", "external")}</button>`).join("")}</div>`).join("");
     container.querySelectorAll(".link-btn").forEach((b) => b.addEventListener("click", () => {
-      if (b.dataset.url.startsWith("devskits://")) {
-        window.DevSkitsWindowManager.openApp("browser", { route: b.dataset.url });
-        return;
-      }
-      window.open(b.dataset.url, "_blank", "noopener");
+      window.DevSkitsWindowManager.openApp("browser", { route: b.dataset.url });
     }));
   }
 

--- a/js/apps/phase4-world.js
+++ b/js/apps/phase4-world.js
@@ -19,8 +19,11 @@
     const url = container.querySelector("#nav-url");
 
     function openRoute(route, push = true) {
-      if (/^https?:\/\//i.test(route)) return window.open(route, "_blank", "noopener");
-      page.innerHTML = routePage(route);
+      if (/^https?:\/\//i.test(route)) {
+        page.innerHTML = `<div class="browser-iframe-wrap"><iframe class="browser-iframe" src="${route}" title="External page" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe></div>`;
+      } else {
+        page.innerHTML = routePage(route);
+      }
       url.value = route;
       if (push) {
         history = history.slice(0, pointer + 1);

--- a/style.css
+++ b/style.css
@@ -245,6 +245,8 @@ fieldset,
 .note-input { width: 100%; min-height: 120px; padding: .45rem; font-family: "Courier New", monospace; background: #fff; }
 .tag { border: 1px solid #777; background: #fff; padding: 0 .3rem; font-size: .68rem; }
 .browser-page { background: #fff; min-height: 150px; padding: .55rem; margin-top: .3rem; }
+.browser-iframe-wrap { min-height: 100%; height: clamp(320px, 52vh, 100%); border: 1px solid #8a8a8a; background: #d9d9d9; }
+.browser-iframe { width: 100%; height: 100%; border: 0; background: #fff; }
 .navigator-shell, .inbox-shell, .media-shell, .inbox-main, .start-quick-actions { display: grid; gap: .45rem; }
 .navigator-bar { display: flex; gap: .24rem; flex-wrap: wrap; }
 .navigator-bar input { flex: 1; min-width: 180px; }


### PR DESCRIPTION
### Motivation
- Provide a consistent in-desktop browsing experience by making external social/support links open inside the shell instead of launching external tabs or windows.

### Description
- Updated `js/apps/links.js` so link buttons open via the in-desktop `browser` app (`window.DevSkitsWindowManager.openApp("browser", { route })`) rather than calling `window.open`.
- Changed `js/apps/contact.js` to render URL contact rows as in-app buttons and route them into the desktop `browser` app when clicked.
- Modified the browser handler in `js/apps/phase4-world.js` so `http/https` routes render inside an embedded `<iframe>` in the browser window content area while internal `devskits://` routes continue to render normally.
- Added iframe presentation styles in `style.css` (`.browser-iframe-wrap` and `.browser-iframe`) for proper in-window display and sizing.

### Testing
- Ran static syntax checks with `node --check js/apps/contact.js`, `node --check js/apps/links.js`, and `node --check js/apps/phase4-world.js`, all succeeded. 
- Performed runtime UI validation by serving the build with `python -m http.server 4173` and exercising the flow with Playwright; the Links app was opened and a social link was clicked, confirming the external page loads inside the desktop browser window iframe and the window controls/resize behavior remain available, and a screenshot was captured (`artifacts/social-iframe-window.png`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b485599d1c832da1468b6965721395)