### PR TITLE
Windows 3.1–style staged boot sequence (BIOS → Splash → Load → Desktop)

### DIFF
--- a/boot.css
+++ b/boot.css
@@ -1,0 +1,182 @@
+.boot-screen {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  display: grid;
+  place-items: center;
+  background: #000;
+  color: #e8e8e8;
+  font-family: "Perfect DOS VGA 437", "Courier New", monospace;
+  overflow: hidden;
+}
+
+.boot-overlay {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background:
+    repeating-linear-gradient(to bottom, rgba(255, 255, 255, 0.04) 0 1px, rgba(0, 0, 0, 0.04) 2px 3px),
+    radial-gradient(circle at center, rgba(255, 255, 255, 0.05), rgba(0, 0, 0, 0.5));
+  mix-blend-mode: screen;
+  opacity: 0.3;
+  animation: crt-flicker 0.18s steps(2) infinite;
+}
+
+.boot-stage {
+  width: min(760px, 94vw);
+  position: relative;
+  z-index: 1;
+}
+
+.boot-stage-bios {
+  min-height: 250px;
+  align-self: center;
+}
+
+.bios-lines {
+  font-size: clamp(13px, 2.8vw, 18px);
+  line-height: 1.5;
+  white-space: pre-wrap;
+  letter-spacing: 0.2px;
+  text-shadow: 0 0 6px rgba(218, 218, 218, 0.3);
+}
+
+.bios-line {
+  margin: 0;
+  animation: text-jitter 1.2s steps(2, end) infinite;
+}
+
+.bios-cursor {
+  margin: 8px 0 0;
+  animation: blink 0.9s steps(1, end) infinite;
+}
+
+.boot-stage-splash {
+  background: #c0c0c0;
+  color: #000;
+  border: 2px solid #fff;
+  border-right-color: #5f5f5f;
+  border-bottom-color: #5f5f5f;
+  padding: 20px 18px;
+  box-shadow: 4px 4px 0 #202020;
+}
+
+.splash-shell {
+  text-align: center;
+  font-family: "MS Sans Serif", Tahoma, sans-serif;
+}
+
+.splash-logo svg {
+  width: min(180px, 42vw);
+  height: auto;
+  image-rendering: pixelated;
+}
+
+.boot-stage-splash h1 {
+  margin: 8px 0 2px;
+  font-size: clamp(24px, 5.5vw, 34px);
+  letter-spacing: 0.4px;
+}
+
+.boot-stage-splash h2 {
+  margin: 0;
+  font-size: clamp(13px, 3.7vw, 20px);
+  font-weight: 600;
+}
+
+.splash-subtitle {
+  margin: 12px 0 10px;
+  font-size: clamp(11px, 2.8vw, 14px);
+}
+
+.loading-dots::after {
+  content: "";
+  display: inline-block;
+  width: 1.5em;
+  text-align: left;
+  animation: dots 1.2s steps(4, end) infinite;
+}
+
+.retro-progress {
+  margin: 8px auto 12px;
+  width: min(360px, 80vw);
+  height: 18px;
+  background: #fff;
+  border: 2px solid #808080;
+  border-right-color: #fff;
+  border-bottom-color: #fff;
+}
+
+.retro-progress span {
+  display: block;
+  height: 100%;
+  width: 0;
+  background: repeating-linear-gradient(90deg, #00008b 0 10px, #1c4ad8 10px 20px);
+}
+
+.system-messages {
+  text-align: left;
+  margin: 0 auto;
+  width: min(500px, 82vw);
+  min-height: 110px;
+  font-family: "Courier New", monospace;
+  font-size: clamp(11px, 2.3vw, 13px);
+}
+
+.system-message {
+  margin: 3px 0;
+}
+
+.final-ready {
+  margin: 12px 0 0;
+  font-weight: bold;
+  animation: text-jitter 0.9s steps(2, end) infinite;
+}
+
+.boot-skip {
+  margin-top: 10px;
+  border: 1px solid #000;
+  background: #d5d5d5;
+  padding: 2px 8px;
+  font-family: inherit;
+  font-size: 12px;
+}
+
+.boot-complete {
+  animation: boot-fade-out 0.7s ease forwards;
+}
+
+@keyframes dots {
+  0% { content: ""; }
+  25% { content: "."; }
+  50% { content: ".."; }
+  75% { content: "..."; }
+  100% { content: ""; }
+}
+
+@keyframes blink { 50% { opacity: 0; } }
+
+@keyframes crt-flicker {
+  0%, 100% { opacity: 0.24; }
+  50% { opacity: 0.33; }
+}
+
+@keyframes text-jitter {
+  0%, 100% { transform: translate(0, 0); }
+  25% { transform: translate(0.4px, -0.3px); }
+  50% { transform: translate(-0.35px, 0.25px); }
+}
+
+@keyframes boot-fade-out {
+  to { opacity: 0; visibility: hidden; }
+}
+
+@media (max-width: 640px) {
+  .boot-stage-splash {
+    padding: 14px 12px;
+  }
+
+  .retro-progress {
+    height: 16px;
+  }
+}

--- a/boot.html
+++ b/boot.html
@@ -1,0 +1,28 @@
+<div id="boot-screen" class="boot-screen" aria-live="polite">
+  <div class="boot-overlay" aria-hidden="true"></div>
+
+  <section id="boot-stage-bios" class="boot-stage boot-stage-bios">
+    <div id="bios-lines" class="bios-lines"></div>
+    <p class="bios-cursor" aria-hidden="true">█</p>
+  </section>
+
+  <section id="boot-stage-splash" class="boot-stage boot-stage-splash hidden">
+    <div class="splash-shell">
+      <div class="splash-logo" aria-hidden="true">
+        <svg viewBox="0 0 128 96" role="img" aria-label="Retro window logo">
+          <polygon points="12,8 56,0 56,40 12,48" fill="#f72b2b" />
+          <polygon points="60,0 116,8 116,48 60,40" fill="#2fb34f" />
+          <polygon points="12,52 56,44 56,84 12,92" fill="#2367d1" />
+          <polygon points="60,44 116,52 116,92 60,84" fill="#f0c420" />
+        </svg>
+      </div>
+      <h1>Microsoft Windows</h1>
+      <h2>DevSkits Edition 2.0</h2>
+      <p class="splash-subtitle">Starting DevSkits OS<span class="loading-dots"></span></p>
+      <div class="retro-progress" aria-hidden="true"><span id="splash-progress"></span></div>
+      <div id="system-messages" class="system-messages"></div>
+      <p id="final-ready" class="final-ready hidden">DevSkits OS ready.</p>
+      <button id="boot-skip" class="boot-skip" type="button">Press ESC to skip</button>
+    </div>
+  </section>
+</div>

--- a/boot.js
+++ b/boot.js
@@ -1,0 +1,118 @@
+(() => {
+  const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+  function printLine(container, text) {
+    const line = document.createElement("p");
+    line.className = "bios-line";
+    container.appendChild(line);
+
+    return new Promise((resolve) => {
+      let idx = 0;
+      const timer = setInterval(() => {
+        idx += 1;
+        line.textContent = text.slice(0, idx);
+        if (idx >= text.length) {
+          clearInterval(timer);
+          resolve();
+        }
+      }, 22);
+    });
+  }
+
+  async function runSequence(options = {}) {
+    const {
+      onComplete = () => {},
+      onBeforeDesktop = () => {},
+      biosLines = [
+        "Initializing DevSkits BIOS...",
+        "Detecting memory...",
+        "Checking storage devices...",
+        "Loading system modules...",
+        "Mounting DevSkits kernel..."
+      ],
+      systemMessages = [
+        "Loading desktop environment...",
+        "Loading applications...",
+        "Initializing icon system...",
+        "Starting DevSkits services...",
+        "Preparing user interface..."
+      ]
+    } = options;
+
+    const bootScreen = document.querySelector("#boot-screen");
+    const biosStage = document.querySelector("#boot-stage-bios");
+    const splashStage = document.querySelector("#boot-stage-splash");
+    const biosContainer = document.querySelector("#bios-lines");
+    const systemContainer = document.querySelector("#system-messages");
+    const progressBar = document.querySelector("#splash-progress");
+    const readyMessage = document.querySelector("#final-ready");
+    const skipButton = document.querySelector("#boot-skip");
+
+    if (!bootScreen || !biosStage || !splashStage) {
+      onComplete();
+      return;
+    }
+
+    bootScreen.classList.remove("hidden", "boot-complete");
+    biosStage.classList.remove("hidden");
+    splashStage.classList.add("hidden");
+
+    let cancelled = false;
+    const cleanup = () => document.removeEventListener("keydown", escSkip);
+
+    const skip = () => {
+      cancelled = true;
+      cleanup();
+      bootScreen.classList.add("hidden");
+      onComplete();
+    };
+
+    const escSkip = (e) => {
+      if (e.key === "Escape") skip();
+    };
+
+    skipButton.onclick = skip;
+    document.addEventListener("keydown", escSkip);
+
+    biosContainer.innerHTML = "";
+    for (const line of biosLines) {
+      if (cancelled) return;
+      await printLine(biosContainer, line);
+      await wait(180);
+    }
+
+    if (cancelled) return;
+    await wait(420);
+
+    biosStage.classList.add("hidden");
+    splashStage.classList.remove("hidden");
+    systemContainer.innerHTML = "";
+    progressBar.style.width = "0%";
+    readyMessage.classList.add("hidden");
+
+    for (let i = 0; i < systemMessages.length; i += 1) {
+      if (cancelled) return;
+      const row = document.createElement("p");
+      row.className = "system-message";
+      row.textContent = systemMessages[i];
+      systemContainer.appendChild(row);
+      progressBar.style.width = `${Math.round(((i + 1) / systemMessages.length) * 100)}%`;
+      await wait(380);
+    }
+
+    if (cancelled) return;
+    readyMessage.classList.remove("hidden");
+    await wait(560);
+
+    onBeforeDesktop();
+    bootScreen.classList.add("boot-complete");
+    await wait(720);
+    bootScreen.classList.add("hidden");
+    cleanup();
+    onComplete();
+  }
+
+  window.DevSkitsBoot = {
+    runSequence
+  };
+})();

--- a/index.html
+++ b/index.html
@@ -5,18 +5,36 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>DevSkits 3.1</title>
   <link rel="stylesheet" href="style.css" />
+  <link rel="stylesheet" href="boot.css" />
 </head>
 <body>
   <div id="boot-screen" class="boot-screen" aria-live="polite">
-    <div class="boot-panel">
-      <div id="boot-logo" class="boot-logo" aria-label="DevSkits 3.1 boot logo"></div>
-      <h1>DevSkits 3.1</h1>
-      <p id="boot-status">Initializing identity shell...</p>
-      <div class="boot-progress"><span id="boot-bar"></span></div>
-      <div class="badges">
-        <button id="boot-skip" class="link-btn" type="button">Skip Boot</button>
+    <div class="boot-overlay" aria-hidden="true"></div>
+
+    <section id="boot-stage-bios" class="boot-stage boot-stage-bios">
+      <div id="bios-lines" class="bios-lines"></div>
+      <p class="bios-cursor" aria-hidden="true">█</p>
+    </section>
+
+    <section id="boot-stage-splash" class="boot-stage boot-stage-splash hidden">
+      <div class="splash-shell">
+        <div class="splash-logo" aria-hidden="true">
+          <svg viewBox="0 0 128 96" role="img" aria-label="Retro window logo">
+            <polygon points="12,8 56,0 56,40 12,48" fill="#f72b2b" />
+            <polygon points="60,0 116,8 116,48 60,40" fill="#2fb34f" />
+            <polygon points="12,52 56,44 56,84 12,92" fill="#2367d1" />
+            <polygon points="60,44 116,52 116,92 60,84" fill="#f0c420" />
+          </svg>
+        </div>
+        <h1>Microsoft Windows</h1>
+        <h2>DevSkits Edition 2.0</h2>
+        <p class="splash-subtitle">Starting DevSkits OS<span class="loading-dots"></span></p>
+        <div class="retro-progress" aria-hidden="true"><span id="splash-progress"></span></div>
+        <div id="system-messages" class="system-messages"></div>
+        <p id="final-ready" class="final-ready hidden">DevSkits OS ready.</p>
+        <button id="boot-skip" class="boot-skip" type="button">Press ESC to skip</button>
       </div>
-    </div>
+    </section>
   </div>
 
   <div id="desktop" class="desktop hidden" role="application" aria-label="DevSkits Desktop">
@@ -110,6 +128,7 @@
   <script src="js/apps/phase4-tools.js"></script>
   <script src="js/apps/phase4-world.js"></script>
   <script src="js/apps/phase5-living.js"></script>
+  <script src="boot.js"></script>
   <script src="app.js"></script>
 </body>
 </html>

--- a/js/core/desktop.js
+++ b/js/core/desktop.js
@@ -43,9 +43,7 @@
 
   function applyBranding() {
     const logo = window.DevSkitsBranding?.logos?.devskits31 || "";
-    const bootLogo = document.querySelector("#boot-logo");
     const desktopLogo = document.querySelector("#desktop-brandmark");
-    if (bootLogo) bootLogo.innerHTML = logo;
     if (desktopLogo) desktopLogo.innerHTML = logo;
 
     if (ui.desktop && logo) {
@@ -405,29 +403,31 @@
 
   function startBootSequence() {
     const fastBoot = localStorage.getItem("devskits-fast-boot") === "on";
-    if (fastBoot) return finishBoot();
+    if (fastBoot || !window.DevSkitsBoot?.runSequence) return finishBoot();
 
-    const bar = document.querySelector("#boot-bar");
-    const status = document.querySelector("#boot-status");
-    const lines = W().getBootLines?.() || ["Initializing identity shell...", "Ready."];
-    const skipBtn = document.querySelector("#boot-skip");
-    let i = 0;
-    bar.style.width = "0%";
+    const profile = W().getProfile?.() || { bootCount: 1 };
+    const build = W().getUpdates?.().currentBuild || "DSK-200";
+    const biosLines = [
+      `Initializing DevSkits BIOS / ${build}...`,
+      "Detecting memory...",
+      `Checking storage devices... (${profile.bootCount} boots logged)`,
+      "Loading system modules...",
+      "Mounting DevSkits kernel..."
+    ];
 
-    const timer = setInterval(() => {
-      i += 1;
-      bar.style.width = `${Math.min(100, (i / lines.length) * 100)}%`;
-      status.textContent = lines[Math.min(i - 1, lines.length - 1)];
-      if (i >= lines.length) {
-        clearInterval(timer);
-        finishBoot();
-      }
-    }, 420);
+    const systemMessages = [
+      "Loading desktop environment...",
+      "Loading applications...",
+      "Initializing icon system...",
+      "Starting DevSkits services...",
+      "Preparing user interface..."
+    ];
 
-    skipBtn.onclick = () => {
-      clearInterval(timer);
-      finishBoot();
-    };
+    window.DevSkitsBoot.runSequence({
+      biosLines,
+      systemMessages,
+      onComplete: finishBoot
+    });
   }
 
   function initDesktop() {

--- a/style.css
+++ b/style.css
@@ -33,7 +33,6 @@ body {
 .taskbar,
 .start-menu,
 .context-menu,
-.boot-panel,
 .run-panel,
 .desktop-icon .icon-glyph,
 .system-tray,
@@ -73,12 +72,6 @@ fieldset,
   border-bottom-color: var(--border-light);
 }
 
-.boot-screen { position: fixed; inset: 0; background: #000; color: #ddd; display: grid; place-items: center; padding: 1rem; }
-.boot-panel { width: min(760px, 100%); background: #101010; padding: .9rem; box-shadow: none; }
-.boot-logo { margin: 0 auto .55rem; width: min(440px, 92vw); }
-.boot-logo svg { width: 100%; height: auto; display: block; }
-.boot-progress { height: 18px; background: #111; margin-top: .65rem; }
-.boot-progress span { display: block; height: 100%; width: 0; background: repeating-linear-gradient(90deg, #fff 0 8px, #a8a8a8 8px 16px); }
 
 .desktop {
   position: fixed;


### PR DESCRIPTION
### Motivation
- Replace the single-panel boot UI with a nostalgic Windows-3.1-inspired, multi-stage startup that runs before the DevSkits desktop loads. 
- Preserve existing boot behavior (fast-boot / session restore) while making the boot flow modular and reusable. 

### Description
- Added a dedicated modular boot controller `boot.js` that exposes `window.DevSkitsBoot.runSequence()` and implements the staged flow (typewriter BIOS lines, centered Windows-like splash with retro SVG logo, sequential system messages, progress updates, skip via ESC/button, and a fade transition to desktop). 
- Added `boot.css` for the retro visual language (light gray splash, four-color window-style SVG, CRT flicker, scanlines, blinking cursor, pixel-style fonts, minimal animations, and responsive layout) and `boot.html` as a standalone reference for the boot markup. 
- Updated `index.html` to include the staged boot markup and load `boot.css` and `boot.js`, and refactored `js/core/desktop.js` to call `DevSkitsBoot.runSequence()` (providing BIOS and system message arrays) while preserving the fast-boot shortcut and existing session restore logic. 
- Cleaned up legacy single-panel boot markup/logic and removed boot-specific bits from `style.css` so the dedicated `boot.css` controls the startup visuals without breaking desktop integration. 

### Testing
- Ran `node --check boot.js` to validate `boot.js` syntax and it succeeded. 
- Ran `node --check js/core/desktop.js` to validate the modified desktop integration and it succeeded. 
- Brought up a simple file server with `python3 -m http.server 4173` and attempted an automated Playwright screenshot to validate visuals, but the Chromium run crashed with a SIGSEGV in this environment so screenshot capture failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b486c6cc34832da5b2cb47be617df3)