### PR TITLE
Open social links in external browser tabs

### DIFF
--- a/js/apps/links.js
+++ b/js/apps/links.js
@@ -5,7 +5,9 @@
     const groups = window.DevSkitsSystemData.links;
     container.innerHTML = Object.entries(groups).map(([group, rows]) => `<h4>${group.toUpperCase()}</h4><div class="app-grid">${rows.map((row) => `<button class="link-btn icon-btn" data-url="${row.url}">${icon(row.icon, row.label)} ${row.label} ${icon("external", "external")}</button>`).join("")}</div>`).join("");
     container.querySelectorAll(".link-btn").forEach((b) => b.addEventListener("click", () => {
-      window.DevSkitsWindowManager.openApp("browser", { route: b.dataset.url });
+      const { url } = b.dataset;
+      if (/^https?:\/\//i.test(url)) return window.open(url, "_blank", "noopener");
+      window.DevSkitsWindowManager.openApp("browser", { route: url });
     }));
   }
 


### PR DESCRIPTION
### Motivation
- External social links should open in the user’s real browser instead of loading inside the app's internal iframe to preserve expected navigation behavior and security.

### Description
- Updated `js/apps/links.js` to read the button `data-url` and detect `http(s)` links. 
- External `http://` and `https://` URLs are now opened with `window.open(url, "_blank", "noopener")`. 
- Internal `devskits://` routes still launch the internal Navigator app via `window.DevSkitsWindowManager.openApp("browser", { route })`.
- Change is a minimal click-handler update with no UI modifications. 

### Testing
- Ran `git diff --check` and it returned clean results. 
- Served the site locally with `python3 -m http.server 4173` and manually verified the Links app loaded. 
- Executed a Playwright run that captured a screenshot of the Links app state (artifact produced) to validate behavior. 
- Committed the change to the repository successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b488196d88832d9f9b600ac5ce6415)