### PR TITLE
Update boot splash heading to DevSkits 3.1

### DIFF
--- a/boot.html
+++ b/boot.html
@@ -17,7 +17,7 @@
         </svg>
       </div>
       <h1>Microsoft Windows</h1>
-      <h2>DevSkits Edition 2.0</h2>
+      <h2>DevSkits 3.1</h2>
       <p class="splash-subtitle">Starting DevSkits OS<span class="loading-dots"></span></p>
       <div class="retro-progress" aria-hidden="true"><span id="splash-progress"></span></div>
       <div id="system-messages" class="system-messages"></div>

--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
           </svg>
         </div>
         <h1>Microsoft Windows</h1>
-        <h2>DevSkits Edition 2.0</h2>
+        <h2>DevSkits 3.1</h2>
         <p class="splash-subtitle">Starting DevSkits OS<span class="loading-dots"></span></p>
         <div class="retro-progress" aria-hidden="true"><span id="splash-progress"></span></div>
         <div id="system-messages" class="system-messages"></div>


### PR DESCRIPTION
### Motivation
- Align the boot animation text with the project version and branding so the splash screen shows `DevSkits 3.1` instead of the outdated `DevSkits Edition 2.0`.

### Description
- Replaced the splash heading text from `DevSkits Edition 2.0` to `DevSkits 3.1` in both `index.html` and `boot.html` so both boot entry points display the same version.

### Testing
- Verified the change with `rg -n "DevSkits Edition 2.0|DevSkits 3.1" index.html boot.html` which confirmed the old text is removed and the new text is present; this check succeeded.
- Attempted to start a local server with `python3 -m http.server 4173` and capture a screenshot via Playwright, but the browser could not load the local page in this environment (`ERR_FILE_NOT_FOUND` / `ERR_EMPTY_RESPONSE`), so visual verification via automated screenshot failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4891fc0d0832da9642b2748889a81)