### PR TITLE
Open contact links externally and remove iframe embedding

### DIFF
--- a/js/apps/contact.js
+++ b/js/apps/contact.js
@@ -18,7 +18,7 @@
     }));
 
     container.querySelectorAll(".contact-url").forEach((btn) => btn.addEventListener("click", () => {
-      window.DevSkitsWindowManager.openApp("browser", { route: btn.dataset.url });
+      window.open(btn.dataset.url, "_blank", "noopener,noreferrer");
     }));
 
     container.querySelector("#vcard-download").addEventListener("click", () => {

--- a/js/apps/phase4-world.js
+++ b/js/apps/phase4-world.js
@@ -20,7 +20,8 @@
 
     function openRoute(route, push = true) {
       if (/^https?:\/\//i.test(route)) {
-        page.innerHTML = `<div class="browser-iframe-wrap"><iframe class="browser-iframe" src="${route}" title="External page" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe></div>`;
+        window.open(route, "_blank", "noopener,noreferrer");
+        page.innerHTML = `<div class="retro-web"><h3>External link opened</h3><p>${route}</p></div>`;
       } else {
         page.innerHTML = routePage(route);
       }

--- a/style.css
+++ b/style.css
@@ -238,8 +238,6 @@ fieldset,
 .note-input { width: 100%; min-height: 120px; padding: .45rem; font-family: "Courier New", monospace; background: #fff; }
 .tag { border: 1px solid #777; background: #fff; padding: 0 .3rem; font-size: .68rem; }
 .browser-page { background: #fff; min-height: 150px; padding: .55rem; margin-top: .3rem; }
-.browser-iframe-wrap { min-height: 100%; height: clamp(320px, 52vh, 100%); border: 1px solid #8a8a8a; background: #d9d9d9; }
-.browser-iframe { width: 100%; height: 100%; border: 0; background: #fff; }
 .navigator-shell, .inbox-shell, .media-shell, .inbox-main, .start-quick-actions { display: grid; gap: .45rem; }
 .navigator-bar { display: flex; gap: .24rem; flex-wrap: wrap; }
 .navigator-bar input { flex: 1; min-width: 180px; }


### PR DESCRIPTION
### Motivation
- The in-app browser used iframes to embed external `http(s)` pages and routed contact URLs through that iframe, which should instead open in the system browser for safety and expected behavior.

### Description
- Updated `js/apps/contact.js` so contact URL buttons call `window.open(..., "_blank", "noopener,noreferrer")` instead of opening the in-app browser app.
- Updated `js/apps/phase4-world.js` to stop rendering external `http(s)` routes in an `<iframe>` and instead call `window.open(...)` and show a small in-app status message.
- Removed the now-unused iframe-specific CSS rules from `style.css` to clean up layout styles.

### Testing
- Ran `rg -n "iframe|IFrame|browser-iframe" js style.css` and confirmed there are no remaining iframe references (passes).
- Performed static syntax checks with `node --check js/apps/contact.js` and `node --check js/apps/phase4-world.js` (both pass).
- Launched a local static server and executed a UI run that opened the Contact app and produced a screenshot showing external-link behavior (Playwright run completed and screenshot artifact created).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b48a3bebec832d976fb79cfd9a0920)