### PR TITLE
Improve mobile usability: touch-to-open icons, movable/resizable windows, and cleaner Start menu

### DIFF
--- a/js/core/desktop.js
+++ b/js/core/desktop.js
@@ -243,6 +243,11 @@
         saveIconPosition(entry.id, safe.x, safe.y);
         suppressClick = true;
         setTimeout(() => { suppressClick = false; }, 140);
+      } else if (e.pointerType === "touch") {
+        suppressClick = true;
+        setTimeout(() => { suppressClick = false; }, 220);
+        selectIcon(entry.id, true);
+        launchDesktopEntry(entry);
       }
       document.body.classList.remove("dragging-icons");
       node.classList.remove("dragging");

--- a/js/core/state.js
+++ b/js/core/state.js
@@ -80,11 +80,9 @@
   };
 
   const START_MENU_SECTIONS = [
-    { id: "identity", label: "IDENTITY", items: ["about", "contact", "links", "donate", "loki"] },
-    { id: "workspace", label: "WORKSPACE", items: ["files", "notes", "projects", "browser", "search", "reminders", "draftpad"] },
-    { id: "tools", label: "TOOLS", items: ["settings", "terminal", "calculator", "calendar", "clock", "asciimaker", "quoteforge"] },
-    { id: "system", label: "SYSTEM", items: ["activity", "processmon", "profile", "presence", "syslogs", "updater", "recycle"] },
-    { id: "extras", label: "EXTRAS", items: ["networkmap", "lokigame", "inbox", "mediadeck", "buildlog", "packages", "achievements"] },
+    { id: "favorites", label: "FAVORITES", items: ["about", "contact", "projects", "notes", "terminal"] },
+    { id: "workspace", label: "WORKSPACE", items: ["files", "browser", "settings", "recycle"] },
+    { id: "links", label: "WEB + LINKS", items: ["links", "donate", "loki"] },
     { id: "power", label: "POWER", items: ["run", "reboot", "shutdown"] }
   ];
 

--- a/js/core/window-manager.js
+++ b/js/core/window-manager.js
@@ -131,7 +131,7 @@
     let drag = null;
     bar.addEventListener("pointerdown", (e) => {
       const rec = state.windows.get(appId);
-      if (!rec || rec.maximized || e.target.closest("button") || window.innerWidth <= 760) return;
+      if (!rec || rec.maximized || e.target.closest("button")) return;
       const rect = win.getBoundingClientRect();
       drag = { x: e.clientX - rect.left, y: e.clientY - rect.top };
       bar.setPointerCapture(e.pointerId);
@@ -155,7 +155,7 @@
     let resize = null;
     handle.addEventListener("pointerdown", (e) => {
       const rec = state.windows.get(appId);
-      if (!rec || rec.maximized || window.innerWidth <= 760) return;
+      if (!rec || rec.maximized) return;
       const rect = win.getBoundingClientRect();
       resize = { w: rect.width, h: rect.height, x: e.clientX, y: e.clientY };
       handle.setPointerCapture(e.pointerId);
@@ -163,8 +163,10 @@
     handle.addEventListener("pointermove", (e) => {
       if (!resize) return;
       const bounds = viewportBounds();
-      const w = Math.max(280, resize.w + (e.clientX - resize.x));
-      const h = Math.max(190, resize.h + (e.clientY - resize.y));
+      const minWidth = window.innerWidth <= 760 ? 220 : 280;
+      const minHeight = window.innerWidth <= 760 ? 160 : 190;
+      const w = Math.max(minWidth, resize.w + (e.clientX - resize.x));
+      const h = Math.max(minHeight, resize.h + (e.clientY - resize.y));
       win.style.width = `${Math.min(w, bounds.width)}px`;
       win.style.height = `${Math.min(h, bounds.height)}px`;
     });
@@ -259,6 +261,13 @@
     if (!items.length) {
       launchApp("about");
       launchApp("contact");
+    }
+
+    const hasTerminal = [...state.windows.values()].some((rec) => rec.appId === "terminal");
+    if (!hasTerminal) {
+      launchApp("terminal");
+      const terminalWindowId = [...state.windows.entries()].find(([, rec]) => rec.appId === "terminal")?.[0];
+      if (terminalWindowId) minimizeWindow(terminalWindowId);
     }
   }
 

--- a/style.css
+++ b/style.css
@@ -273,14 +273,16 @@ body.reduce-motion .window { transition: none; }
   .desktop-icons { overflow-y: auto; overflow-x: hidden; padding-right: 2px; }
   .window-layer { inset: 0 0 var(--taskbar-h) 0; }
   .window {
-    min-width: 0;
-    min-height: 0;
+    min-width: 220px;
+    min-height: 160px;
     width: calc(100vw - 10px);
     height: calc(100vh - var(--taskbar-h) - 10px);
-    left: 5px !important;
-    top: 5px !important;
   }
-  .resize-handle { display: none; }
+  .resize-handle {
+    display: block;
+    width: 22px;
+    height: 22px;
+  }
   .window-titlebar { min-height: 30px; }
   .window-controls button { width: 28px; height: 24px; }
   .icon-label { font-size: 11px; }


### PR DESCRIPTION
### Motivation
- Make the desktop usable on phones by allowing windows to be moved and resized on touch devices and by making desktop icons reliably open on tap.
- Ensure Terminal is available after restore without blocking the desktop by launching it minimized.
- Reduce clutter in the Start Menu to surface commonly used, launchable entries for quick access on small screens.

### Description
- Relaxed mobile guards in `js/core/window-manager.js` so titlebar dragging and resize work on narrow viewports, and added mobile-friendly minimum sizes for resize calculations in `enableResize`.
- Ensure a Terminal window is launched during `restoreSession` when none exists and immediately minimized so it appears in the taskbar but stays out of the way (`js/core/window-manager.js`).
- Updated desktop icon interaction so a touch `pointerup` (when not a drag) will select and launch the entry and suppress duplicate click events (`js/core/desktop.js`).
- Reorganized `START_MENU_SECTIONS` to a streamlined `FAVORITES`/`WORKSPACE`/`WEB + LINKS`/`POWER` layout in `js/core/state.js`, and adjusted mobile CSS in `style.css` to keep resize handle visible and remove hard-pinned positioning on small screens.

### Testing
- Static syntax checks passed: `node --check js/core/window-manager.js && node --check js/core/desktop.js && node --check js/core/state.js` (passed).
- Served the app with `python -m http.server` and attempted a Playwright mobile screenshot, but the headless browser run failed with `net::ERR_EMPTY_RESPONSE` in this environment so no screenshot artifact was produced (attempted and failed).
- All code changes were lint-checked via the Node syntax checks listed above and no runtime syntax errors were reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b48e0347b4832da9474a1245f5dc75)